### PR TITLE
Remove keyword args to be compatible ruby 1.9 series

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -2,9 +2,8 @@ require 'yaml'
 
 module Parity
   class Backup
-    def initialize(from: from, to: to)
-      @from = from
-      @to = to
+    def initialize(args)
+      @from, @to = args.values_at(:from, :to)
     end
 
     def restore


### PR DESCRIPTION
The current implementation only uses keyword args at one point, so ruby 2.0
is not really needed.

Also, a lot of projects still uses ruby 1.9, so the loaded ruby will be the
1.9 (to run tests, app etc).

So I think that is a good idea to support the 1.9 series.

PS: This gem rocks! Thank you :sparkles:
