### PR TITLE
Allow running e.g. `production open`

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -10,13 +10,21 @@ module Parity
       if self.class.private_method_defined?(subcommand)
         send(subcommand)
       else
-        Kernel.system "heroku #{pass_through} --remote #{environment}"
+        run_via_cli
       end
     end
 
     private
 
     attr_accessor :environment, :subcommand, :arguments
+
+    def open
+      run_via_cli
+    end
+
+    def run_via_cli
+      Kernel.system "heroku #{pass_through} --remote #{environment}"
+    end
 
     def backup
       Kernel.system "heroku pgbackups:capture --expire --remote #{environment}"
@@ -50,7 +58,7 @@ module Parity
     end
 
     def pass_through
-      [subcommand, arguments].join(' ')
+      [subcommand, arguments].join(' ').strip
     end
   end
 end

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -41,6 +41,14 @@ describe Parity::Environment do
     expect(Kernel).to have_received(:system).with(tail)
   end
 
+  it 'opens the app' do
+    Kernel.stub(:system)
+
+    Parity::Environment.new('production', ['open']).run
+
+    expect(Kernel).to have_received(:system).with(open)
+  end
+
   def heroku_backup
     "heroku pgbackups:capture --expire --remote production"
   end
@@ -62,5 +70,9 @@ describe Parity::Environment do
 
   def tail
     "heroku logs --tail --remote production"
+  end
+
+  def open
+    "heroku open --remote production"
   end
 end


### PR DESCRIPTION
`open` is a private method from somewhere up the inheritance chain, so
Environment tries to call it and crashes. To avoid this, we redefine the `open`
method.
