### PR TITLE
Pass in first argument when restoring into staging

### DIFF
--- a/lib/parity/staging.rb
+++ b/lib/parity/staging.rb
@@ -10,7 +10,7 @@ module Parity
     private
 
     def restore
-      Backup.new(from: arguments.last, to: 'staging').restore
+      Backup.new(from: arguments.first, to: 'staging').restore
     end
   end
 end


### PR DESCRIPTION
Noticed that development.rb uses `first` instead of `last`. So we update
staging.rb for consistency.
