### PR TITLE
Enable redis-cli access to RedisToGo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Tail a log:
 
 Use [redis-cli][2] with your RedisToGo addon:
 
-    production redis_cli
-    staging redis_cli
+    production redis-cli
+    staging redis-cli
 
 The scripts also pass through, so you can do anything with them that you can do
 with `heroku ______ --remote staging` or `heroku ______ --remote production`:
@@ -98,6 +98,7 @@ Override some of the conventions:
 Parity.configure do |config|
   config.database_config_path = 'different/path.yml'
   config.heroku_app_basename = 'different-base-name'
+  config.redis_url_env_variable = 'ENV_VARIABLE_THAT_ISNT_REDIS_URL'
 end
 ```
 

--- a/lib/parity.rb
+++ b/lib/parity.rb
@@ -1,7 +1,7 @@
-require 'parity/configuration'
-require 'parity/environment'
-require 'parity/usage'
-require 'open3'
-require 'uri'
+require "parity/configuration"
+require "parity/environment"
+require "parity/usage"
+require "open3"
+require "uri"
 
 Parity.configure

--- a/lib/parity/configuration.rb
+++ b/lib/parity/configuration.rb
@@ -1,12 +1,13 @@
 module Parity
   class Configuration
-    attr_accessor :database_config_path,
+    attr_accessor \
+      :database_config_path,
       :heroku_app_basename,
       :redis_url_env_variable
 
     def initialize
-      @database_config_path = 'config/database.yml'
-      @redis_url_env_variable = 'REDISTOGO_URL'
+      @database_config_path = "config/database.yml"
+      @redis_url_env_variable = "REDIS_URL"
     end
   end
 

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -9,7 +9,9 @@ module Parity
     end
 
     def run
-      if self.class.private_method_defined?(subcommand)
+      if subcommand == "redis-cli"
+        redis_cli
+      elsif self.class.private_method_defined?(subcommand)
         send(subcommand)
       else
         run_via_cli
@@ -66,7 +68,13 @@ module Parity
       url = URI(raw_redis_url)
 
       Kernel.system(
-        "redis-cli -h #{url.host} -p #{url.port} -a #{url.password}"
+        "redis-cli",
+        "-h",
+        url.host,
+        "-p",
+        url.port,
+        "-a",
+        url.password
       )
     end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,11 +1,11 @@
-require File.join(File.dirname(__FILE__), '..', 'lib', 'parity')
+require File.join(File.dirname(__FILE__), "..", "lib", "parity")
 
 describe Parity::Configuration do
   describe "#redis_url_env_variable" do
-    it "is set to REDISTOGO_URL by default" do
+    it "is set to REDIS_URL by default" do
       configuration = Parity::Configuration.new
 
-      expect(configuration.redis_url_env_variable).to eq("REDISTOGO_URL")
+      expect(configuration.redis_url_env_variable).to eq("REDIS_URL")
     end
 
     it "can be overridden" do

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -103,7 +103,15 @@ describe Parity::Environment do
 
     Parity::Environment.new("production", ["redis_cli"]).run
 
-    expect(Kernel).to have_received(:system).with(redis_cli)
+    expect(Kernel).to have_received(:system).with(
+      "redis-cli",
+      "-h",
+      "landshark.redistogo.com",
+      "-p",
+      90210,
+      "-a",
+      "abcd1234efgh5678"
+    )
     expect(Open3).
       to have_received(:capture3).
       with(fetch_redis_url).


### PR DESCRIPTION
Accomplish the functionality described in
https://github.com/croaky/parity/issues/8. Using `Open3` from the standard
library to capture the output of the request to Heroku for the URL, which is
then memoized and parsed with regex to get the host, post, and password.

User can then access their RedisToGo with `production redis-cli`.
