### PR TITLE
Consistent sh-bang lines.

### DIFF
--- a/bin/development
+++ b/bin/development
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 require File.join(File.dirname(__FILE__), '..', 'lib', 'parity')
 


### PR DESCRIPTION
`bin/development` was hard-coded to use `/usr/bin/ruby`, while all the other bin files use `/usr/bin/env ruby`.
