### PR TITLE
Fix data type bug in `redis-cli` command

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -72,7 +72,7 @@ module Parity
         "-h",
         url.host,
         "-p",
-        url.port,
+        url.port.to_s,
         "-a",
         url.password
       )

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -109,7 +109,7 @@ describe Parity::Environment do
       "-h",
       "landshark.redistogo.com",
       "-p",
-      90210,
+      "90210",
       "-a",
       "abcd1234efgh5678"
     )


### PR DESCRIPTION
While stubbing out `Kernel.system` for the `redis-cli` command, I missed that
`Kernel.system` only takes strings as arguments, so the port number must be
converted to a string. Avoiding the conversion on hostname and password
(presumably to avoid `nil`) because Heroku Redis providers will always require 
a password.

Fix #17.
