### PR TITLE
Fix usage problem due to README changes

### DIFF
--- a/lib/parity/usage.rb
+++ b/lib/parity/usage.rb
@@ -1,7 +1,7 @@
 module Parity
   class Usage
     def to_s
-      File.read(readme).match(/Usage\n-----\n([^\/.]*)Convention/)[1]
+      File.read(readme).match(/Usage\n-----\n([^\/.]*)staging open/)[1]
     end
 
     private


### PR DESCRIPTION
Changes made in 3b9378cab79b4d2b0000766ccaec1a2bbde83c8d broke
the regex that took the Usage slice out of README.md. This change to the
regex results in the correct excerpt being pulled.