### PR TITLE
Allow bypass of confirmation when restoring to staging

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -50,8 +50,20 @@ module Parity
         Backup.new(
           from: arguments.first,
           to: environment,
-          additional_args: arguments.drop(1).join(" ")
+          additional_args: additional_restore_arguments,
         ).restore
+      end
+    end
+
+    def additional_restore_arguments
+      (arguments.drop(1) + [restore_confirmation_argument]).
+        compact.
+        join(" ")
+    end
+
+    def restore_confirmation_argument
+      if !["production", "development"].include?(environment)
+        "--confirm #{heroku_app_name}"
       end
     end
 

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -20,31 +20,33 @@ describe Parity::Environment do
     expect(Kernel).to have_received(:system).with(heroku_backup)
   end
 
-  it "restores backups from production to staging" do
+  it "restores backups from production to staging with the confirmation argument" do
+    backup = double("backup", restore: nil)
+    allow(Parity::Backup).to receive(:new).and_return(backup)
+
+    Parity::Environment.new("staging", ["restore", "production"]).run
+
+    expect(Parity::Backup).
+      to have_received(:new).
+      with(
+        from: "production",
+        to: "staging",
+        additional_args: "--confirm parity-staging",
+      )
+    expect(backup).to have_received(:restore)
+  end
+
+  it "passes the confirm argument when restoring to a  non-production environment" do
     backup = double("backup", restore: nil)
     allow(Parity::Backup).to receive(:new).and_return(backup)
 
     Parity::Environment.new("staging", ["restore", "production"]).run
 
     expect(Parity::Backup).to have_received(:new).
-      with(from: "production", to: "staging", additional_args: "")
-    expect(backup).to have_received(:restore)
-  end
-
-  it "passes arguments to the restore command when used against staging" do
-    backup = double("backup", restore: nil)
-    allow(Parity::Backup).to receive(:new).and_return(backup)
-
-    Parity::Environment.new(
-      "staging",
-      ["restore", "production", "--confirm", "myappname-staging"]
-    ).run
-
-    expect(Parity::Backup).to have_received(:new).
       with(
         from: "production",
         to: "staging",
-        additional_args: "--confirm myappname-staging"
+        additional_args: "--confirm parity-staging",
       )
     expect(backup).to have_received(:restore)
   end


### PR DESCRIPTION
Heroku asks for confirmation with `--confirm appname` when performing
potentially destructive CLI operations such as a database restore. If
staging data is tracking with production or easily rebuilt using seeds,
this confirmation can be annoying, particularly during the common
operation of taking a snapshot of production and then immediately
copying it to staging to sync staging's DB up with production's.

This change changes the behavior of non-production, non-local
development environments to append the confirmation argument on database
restores to overwrite the staging or other feature environment database
when restored from another environment.

 Close #38.