### PR TITLE
Remove log2viz

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,6 @@ Open a console:
     production console
     staging console
 
-Open [log2viz][1]:
-
-    production log2viz
-    staging log2viz
-
 Migrate a database and restart the dynos:
 
     production migrate
@@ -84,7 +79,6 @@ with `heroku ______ --remote staging` or `heroku ______ --remote production`:
     watch production ps
     staging open
 
-[1]: https://blog.heroku.com/archives/2013/3/19/log2viz
 [2]: http://redis.io/commands
 
 Convention

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -61,10 +61,6 @@ module Parity
       Kernel.system "heroku run rails console --remote #{environment}"
     end
 
-    def log2viz
-      Kernel.system "open https://log2viz.herokuapp.com/app/#{heroku_app_name}"
-    end
-
     def migrate
       Kernel.system %{
         heroku run rake db:migrate --remote #{environment} &&

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -91,14 +91,6 @@ describe Parity::Environment do
     expect(Kernel).to have_received(:system).with(heroku_console)
   end
 
-  it "opens the log2viz visualization" do
-    allow(Kernel).to receive(:system)
-
-    Parity::Environment.new("production", ["log2viz"]).run
-
-    expect(Kernel).to have_received(:system).with(heroku_log2viz)
-  end
-
   it "automatically restarts processes when it migrates the database" do
     allow(Kernel).to receive(:system)
 
@@ -176,10 +168,6 @@ describe Parity::Environment do
 
   def heroku_console
     "heroku run rails console --remote production"
-  end
-
-  def heroku_log2viz
-    "open https://log2viz.herokuapp.com/app/parity-production"
   end
 
   def git_push


### PR DESCRIPTION
Why:

* `log2viz` was useful before Heroku's application metrics existed.
  https://devcenter.heroku.com/articles/metrics
* Other alternatives include New Relic and Skylight.

How it addresses the need:

* Remove the feature.