### PR TITLE
Deploy feature branches to staging or feature envs

### DIFF
--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -171,6 +171,14 @@ describe Parity::Environment do
     expect(Kernel).not_to have_received(:system).with(migrate)
   end
 
+  it "deploys feature branches to staging's master for evaluation" do
+    allow(Kernel).to receive(:system)
+
+    Parity::Environment.new("staging", ["deploy"]).run
+
+    expect(Kernel).to have_received(:system).with(git_push_feature_branch)
+  end
+
   def heroku_backup
     "heroku pg:backups capture --remote production"
   end
@@ -181,6 +189,10 @@ describe Parity::Environment do
 
   def git_push
     "git push production master"
+  end
+
+  def git_push_feature_branch
+    "git push staging HEAD:master --force"
   end
 
   def skip_migration


### PR DESCRIPTION
When working on a non-trivial feature, it is often desirable to be able
to push the unmerged feature branch to the staging environment (or a
feature-specific environment) without merging it to master (on many
projects master is considered "ready to deploy").

This change alters the `deploy` subcommand for non-production
environments to push a non-master branch to the desired Heroku
environment's master branch (`git push staging` will actually push your
feature branch to a useless feature branch that doesn't get deployed on
staging) so that feature branches can be evaluated
without requiring a merge to master that might then have to be undone or
accidentally deployed to production.