### PR TITLE
Restore local development DB to staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,10 @@ On other systems you can:
 Parity requires these command-line programs:
 
     git
-    curl
     heroku
     pg_restore
 
-On OS X,
-`curl` is installed by default.
-The other programs are installed
+On OS X, these programs are installed
 as Homebrew package dependencies of
 the `parity` Homebrew package.
 
@@ -47,6 +44,10 @@ Restore a production or staging database backup into development:
 Restore a production database backup into staging:
 
     staging restore production
+
+Push your local development database backup up to staging:
+
+    development restore staging
 
 Deploy from master, and migrate and restart the dynos if necessary:
 

--- a/spec/backup_spec.rb
+++ b/spec/backup_spec.rb
@@ -10,15 +10,32 @@ describe Parity::Backup do
 
     Parity::Backup.new(from: "production", to: "development").restore
 
-    expect(Kernel).to have_received(:system).with(curl_piped_to_pg_restore)
+    expect(Kernel).
+      to have_received(:system).
+      with(heroku_production_to_development_passthrough)
   end
 
-  it "restores backups to staging" do
+  it "restores backups to staging from production" do
     allow(Kernel).to receive(:system)
 
     Parity::Backup.new(from: "production", to: "staging").restore
 
-    expect(Kernel).to have_received(:system).with(heroku_pass_through)
+    expect(Kernel).
+      to have_received(:system).
+      with(heroku_production_to_staging_passthrough)
+  end
+
+  it "restores backups to staging from development" do
+    Parity.configure do |config|
+      config.database_config_path = database_config_path
+    end
+    allow(Kernel).to receive(:system)
+
+    Parity::Backup.new(from: "development", to: "staging").restore
+
+    expect(Kernel).
+      to have_received(:system).
+      with(heroku_development_to_staging_passthrough)
   end
 
   it "passes additional arguments to the subcommand" do
@@ -38,15 +55,19 @@ describe Parity::Backup do
     File.join(File.dirname(__FILE__), 'fixtures', 'database.yml')
   end
 
-  def curl_piped_to_pg_restore
-    "curl -s `heroku pg:backups public-url --remote production` | #{pg_restore}"
+  def heroku_production_to_development_passthrough
+    "heroku pg:pull DATABASE_URL parity_development --remote production "
   end
 
   def pg_restore
     "pg_restore --verbose --clean --no-acl --no-owner -d parity_development"
   end
 
-  def heroku_pass_through
+  def heroku_development_to_staging_passthrough
+    "heroku pg:push parity_development DATABASE_URL --remote staging "
+  end
+
+  def heroku_production_to_staging_passthrough
     "heroku pg:backups restore `heroku pg:backups public-url "\
       "--remote production` DATABASE --remote staging "
   end


### PR DESCRIPTION
This change allows users to push their local development database up to
staging to permit testing against locally built data or sharing testing
data with teammates. Is uses Heroku's `pg:push` command to deliver the
development environment's database to the staging or other feature
environment.

Other changes:
* Backups *to* development now use Heroku's `pg:pull` command to remove
  the restore functionality's dependency on curl.

Close #46.