### PR TITLE
Don't run `migrate` after a failed deployment

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -35,11 +35,9 @@ module Parity
     end
 
     def deploy
-      skip_migration = skip_migration?
+      deploy_successful = Kernel.system("git push #{environment} master")
 
-      Kernel.system "git push #{environment} master"
-
-      unless skip_migration
+      if deploy_successful && run_migration?
         migrate
       end
     end
@@ -103,8 +101,8 @@ module Parity
       Parity.config.heroku_app_basename || Dir.pwd.split('/').last
     end
 
-    def skip_migration?
-      Kernel.system %{
+    def run_migration?
+      !Kernel.system %{
         git fetch #{environment} &&
         git diff --quiet #{environment}/master..master -- db/migrate
       }

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -142,6 +142,7 @@ describe Parity::Environment do
 
   it "deploys the application and runs migrations when required" do
     allow(Kernel).to receive(:system)
+    allow(Kernel).to receive(:system).with(git_push).and_return(true)
     allow(Kernel).to receive(:system).with(skip_migration).and_return(false)
 
     Parity::Environment.new("production", ["deploy"]).run
@@ -153,12 +154,24 @@ describe Parity::Environment do
 
   it "deploys the application and skips migrations when not required" do
     allow(Kernel).to receive(:system)
+    allow(Kernel).to receive(:system).with(git_push).and_return(true)
     allow(Kernel).to receive(:system).with(skip_migration).and_return(true)
 
     Parity::Environment.new("production", ["deploy"]).run
 
     expect(Kernel).to have_received(:system).with(git_push)
     expect(Kernel).to have_received(:system).with(skip_migration)
+    expect(Kernel).not_to have_received(:system).with(migrate)
+  end
+
+  it "does not run migrations if the deploy failed" do
+    allow(Kernel).to receive(:system)
+    allow(Kernel).to receive(:system).with(git_push).and_return(false)
+    allow(Kernel).to receive(:system).with(skip_migration).and_return(false)
+
+    Parity::Environment.new("production", ["deploy"]).run
+
+    expect(Kernel).to have_received(:system).with(git_push)
     expect(Kernel).not_to have_received(:system).with(migrate)
   end
 


### PR DESCRIPTION
Don't run migrations after a failed deployment

In 256f9a3f995d21fa6059efcd523855f2a1a0c381 we started returning proper Unix exit status codes after running parity passthrough commands. This change checks the exit status of the "deploy" portion of the `deploy` command to ensure the deployment was successful before attempting to run migrations.

Close #48.