### PR TITLE
Move spec files to match layout of `lib`

### DIFF
--- a/spec/parity/backup_spec.rb
+++ b/spec/parity/backup_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', 'lib', 'parity')
+require File.join(File.dirname(__FILE__), '..', '..', 'lib', 'parity')
 
 describe Parity::Backup do
   it "restores backups to development (after dropping the development DB)" do
@@ -54,7 +54,7 @@ describe Parity::Backup do
   end
 
   def database_fixture_path
-    File.join(File.dirname(__FILE__), 'fixtures', 'database.yml')
+    File.join(File.dirname(__FILE__), '..', 'fixtures', 'database.yml')
   end
 
   def heroku_production_to_development_passthrough

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), "..", "lib", "parity")
+require File.join(File.dirname(__FILE__), '..', '..', 'lib', 'parity')
 
 describe Parity::Environment do
   it "passes through arguments with correct quoting" do

--- a/spec/parity/usage_spec.rb
+++ b/spec/parity/usage_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', 'lib', 'parity')
+require File.join(File.dirname(__FILE__), '..', '..', 'lib', 'parity')
 
 describe Parity::Usage do
   it 'cuts the Usage section out of the README' do


### PR DESCRIPTION
Moving these files into `spec/parity` allows developers to move back and
forth between specs and code using alternate file mappings. It also
makes the layout of `spec` more closely follow the same structure as
`lib` to make navigating the codebase easier.