### PR TITLE
Drop development database before `development restore`

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -31,6 +31,15 @@ module Parity
     end
 
     def restore_to_development
+      drop_development_database
+      pull_remote_database_to_development
+    end
+
+    def drop_development_database
+      Kernel.system("dropdb #{development_db}")
+    end
+
+    def pull_remote_database_to_development
       Kernel.system(
         "heroku pg:pull DATABASE_URL #{development_db} --remote #{from} "\
           "#{additional_args}",

--- a/spec/backup_spec.rb
+++ b/spec/backup_spec.rb
@@ -1,12 +1,15 @@
 require File.join(File.dirname(__FILE__), '..', 'lib', 'parity')
 
 describe Parity::Backup do
-  it "restores backups to development" do
+  it "restores backups to development (after dropping the development DB)" do
     allow(IO).to receive(:read).and_return(database_fixture)
     allow(Kernel).to receive(:system)
 
     Parity::Backup.new(from: "production", to: "development").restore
 
+    expect(Kernel).
+      to have_received(:system).
+      with(drop_development_database_drop_command)
     expect(Kernel).
       to have_received(:system).
       with(heroku_production_to_development_passthrough)
@@ -60,6 +63,10 @@ describe Parity::Backup do
 
   def pg_restore
     "pg_restore --verbose --clean --no-acl --no-owner -d parity_development"
+  end
+
+  def drop_development_database_drop_command
+    "dropdb parity_development"
   end
 
   def heroku_development_to_staging_passthrough


### PR DESCRIPTION
Heroku's CLI tool for `pg:pull` now expects there to be no development
database in place, as it runs `createdb` to attempt to create the
development database before restoring the remote backup locally.

This change runs `dropdb` to clear out the development database before
using Heroku's `pg:pull` to bring the remote backup down to the
development environment.

Close #47.