### PR TITLE
Don't attempt to migrate on deploy for non-Rails apps

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -128,6 +128,14 @@ module Parity
     end
 
     def run_migration?
+      a_rails_app? && pending_migrations?
+    end
+
+    def a_rails_app?
+      Kernel.system("command -v rake && rake -n db:migrate")
+    end
+
+    def pending_migrations?
       !Kernel.system(%{
         git fetch #{environment} &&
         git diff --quiet #{environment}/master..master -- db/migrate


### PR DESCRIPTION
When using Parity with a Python project, the `deploy` subcommand was
causing harmless but annoying error messages when the deploy step for
running migrations was attempted. This change checks that the `rake`
command is available to the application and that the application has a
`db:migrate` task defined (using Rake's `-n` switch for a "dry run").

Other changes:
* Stub out `Kernel.system` in environment specs to always return true
  unless explicitly told otherwise. Many of our specs stubbed out
  `.system` just to keep execution moving forward. Stubbing out across
  all the specs also prevents accidental execution of commands in a spec
  where stubbing was not set up.

Fix #49.