### PR TITLE
Update to correct restoration of db to staging from development

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Restore a production database backup into staging:
 
 Push your local development database backup up to staging:
 
-    development restore staging
+    staging restore development
 
 Deploy from master, and migrate and restart the dynos if necessary:
 


### PR DESCRIPTION
The `README.md` had a slight mistake concerning restoring a development database to a staging environment. This pull request takes care of that.