### PR TITLE
Fix `deploy` problems in 0.9.0

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -9,6 +9,16 @@ module Parity
     end
 
     def run
+      run_command || false
+    end
+
+    private
+
+    PROTECTED_ENVIRONMENTS = %w(development production)
+
+    attr_accessor :environment, :subcommand, :arguments
+
+    def run_command
       if subcommand == "redis-cli"
         redis_cli
       elsif self.class.private_method_defined?(subcommand)
@@ -17,12 +27,6 @@ module Parity
         run_via_cli
       end
     end
-
-    private
-
-    PROTECTED_ENVIRONMENTS = %w(development production)
-
-    attr_accessor :environment, :subcommand, :arguments
 
     def open
       run_via_cli
@@ -37,8 +41,10 @@ module Parity
     end
 
     def deploy
-      if deploy_to_heroku && run_migration?
-        migrate
+      skip_migrations = !run_migrations?
+
+      if deploy_to_heroku
+        skip_migrations || migrate
       end
     end
 
@@ -127,7 +133,7 @@ module Parity
       Dir.pwd.split("/").last
     end
 
-    def run_migration?
+    def run_migrations?
       rails_app? && pending_migrations?
     end
 


### PR DESCRIPTION
v0.9.0 broke `deploy` in two ways. The first is that migrations were
being checked after the deploy completed, which resulted in the check
for diffs in `db/migrate` always finding no differences. This change
reverts to the prior pattern of caching whether migrations are pending
at the start of `deploy` before pushing to Heroku.

The second is that the check for `rake` would raise an exception if a
user's local bundle wasn't installed, as the shell command would return
a failing status. `Kernel.system` can return `true`, `false`, or `nil`,
but `Kernel.exit` can't accept `nil` as an argument.
`Parity::Environment#run` will now always return a boolean value so that
`Kernel.exit` receives an appropriate argument.

Fix #61.