### PR TITLE
Update docs on deploying non-master branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,17 @@ Push your local development database backup up to staging:
 
     staging restore development
 
-Deploy from master, and migrate and restart the dynos if necessary:
+Deploy from master to production
+and migrate and restart the dynos if necessary:
 
     production deploy
+
+Deploy the current branch to staging or a feature branch
+and migrate and restart the dynos if necessary:
+
     staging deploy
+
+_Note that deploys to non-production environments use `git push --force`._
 
 Open a console:
 


### PR DESCRIPTION
In df296fe6e77698fe4522b120944621667b1dcbd3 we added the capability to
push non-master branches to staging or other feature environments for
testing. Pushes to non-production environments are forced in case a
developer has been squashing commits.

This change updates the README to clarify that pushes are permitted from
non-master branches to non-production environments.

Close #56.