### PR TITLE
Alias restore with restore-from for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ Backup a database:
 
 Restore a production or staging database backup into development:
 
-    development restore production
-    development restore staging
+    development restore-from production
+    development restore-from staging
 
 Restore a production database backup into staging:
 
-    staging restore production
+    staging restore-from production
 
 Push your local development database backup up to staging:
 
-    staging restore development
+    staging restore-from development
 
 Deploy from master to production
 and migrate and restart the dynos if necessary:

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -19,10 +19,8 @@ module Parity
     attr_accessor :environment, :subcommand, :arguments
 
     def run_command
-      if subcommand == "redis-cli"
-        redis_cli
-      elsif self.class.private_method_defined?(subcommand)
-        send(subcommand)
+      if self.class.private_method_defined?(methodized_subcommand)
+        send(methodized_subcommand)
       else
         run_via_cli
       end
@@ -70,6 +68,8 @@ module Parity
         ).restore
       end
     end
+
+    alias :restore_from :restore
 
     def production?
       environment == "production"
@@ -154,6 +154,10 @@ module Parity
         git fetch #{environment} &&
         git diff --quiet #{environment}/master..master -- db/migrate
       })
+    end
+
+    def methodized_subcommand
+      subcommand.gsub("-", "_").to_sym
     end
   end
 end

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -47,6 +47,22 @@ RSpec.describe Parity::Environment do
     expect(backup).to have_received(:restore)
   end
 
+  it "restores using restore-from" do
+    backup = double("backup", restore: nil)
+    allow(Parity::Backup).to receive(:new).and_return(backup)
+
+    Parity::Environment.new("staging", ["restore-from", "production"]).run
+
+    expect(Parity::Backup).
+      to have_received(:new).
+      with(
+        from: "production",
+        to: "staging",
+        additional_args: "--confirm parity-staging",
+      )
+    expect(backup).to have_received(:restore)
+  end
+
   it "passes the confirm argument when restoring to a non-prod environment" do
     backup = double("backup", restore: nil)
     allow(Parity::Backup).to receive(:new).and_return(backup)


### PR DESCRIPTION
I find `development restore production` to be confusing at times. I find that I end up looking up the proper syntax quite a bit. I aliased `restore` with `restore_from` because I feel that it describes what I'm trying to accomplish better.

* Private method for methodizing subcommands
* Test it good!