### PR TITLE
Parse git remote name to determine Heroku app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rake'
-gem 'rspec'
+gem "rspec"

--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ Parity expects:
 * A `production` remote pointing to the production Heroku app.
 * There is a `config/database.yml` file that can be parsed as YAML for
   `['development']['database']`.
-* The Heroku apps are named like `app-staging` and `app-production`
-  where `app` is equal to `basename $PWD`.
 
 Customization
 -------------

--- a/lib/parity.rb
+++ b/lib/parity.rb
@@ -3,6 +3,7 @@ $LOAD_PATH << File.expand_path("..", __FILE__)
 require "parity/version"
 require "parity/environment"
 require "parity/usage"
+require "git"
 require "open3"
 require "pathname"
 require "uri"

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -125,12 +125,12 @@ module Parity
       )[0].strip
     end
 
-    def heroku_app_name
-      [basename, environment].join('-')
+    def git_remote
+      Git.init.remote(environment).url
     end
 
-    def basename
-      Dir.pwd.split("/").last
+    def heroku_app_name
+      git_remote.split(":").last.split(".").first
     end
 
     def run_migrations?

--- a/parity.gemspec
+++ b/parity.gemspec
@@ -17,4 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.summary = "Shell commands for development, staging, and production parity."
   spec.version = Parity::VERSION
+
+  spec.add_dependency "git", "~> 1.2"
+  spec.add_dependency "rake", "~> 10.4"
 end


### PR DESCRIPTION
Several reports have matched #72, which was affecting the `restore`
command for some users. The cause turned out to be local folder names
not matching the name of the Heroku app. Now that Heroku tracks Git
remotes, we can take advantage of the Git remote to correctly identify
the app name even the local folder name doesn't match.

While this requirement has existed for the entirety of Parity's
existence, it stopped being a problem for most commands once Heroku
introduced remotes. I inadvertently reintroduced this requirement in
ad2c21a42fb85bd00ec58d7326725f0a1d5a7771 when we started automatically
bypassing confirmation arguments for restores to non-production
environments.

Fix #72.