### PR TITLE
Correctly parse HTTPS Heroku remotes

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -14,6 +14,8 @@ module Parity
 
     private
 
+    GIT_REMOTE_SEGMENT_DELIMITER_REGEX = /[\/:]/
+    GIT_REMOTE_FILE_EXTENSION_REGEX = /\.git$/
     PROTECTED_ENVIRONMENTS = %w(development production)
 
     attr_accessor :environment, :subcommand, :arguments
@@ -130,7 +132,9 @@ module Parity
     end
 
     def heroku_app_name
-      git_remote.split(":").last.split(".").first
+      git_remote.
+        split(GIT_REMOTE_SEGMENT_DELIMITER_REGEX).
+        last.sub(GIT_REMOTE_FILE_EXTENSION_REGEX, "")
     end
 
     def run_migrations?

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -31,9 +31,29 @@ RSpec.describe Parity::Environment do
     expect(Kernel).to have_received(:system).with(heroku_backup)
   end
 
-  it "correctly connects to the Heroku app when the $PWD's name does not match the app's name" do
+  it "correctly connects to the Heroku app when the $PWD's name does not match the app's name (remote uses git:// protocol)" do
     backup = stub_parity_backup
     stub_git_remote(base_name: "parity-integration", environment: "staging")
+    allow(Parity::Backup).to receive(:new).and_return(backup)
+
+    Parity::Environment.new("staging", ["restore", "production"]).run
+
+    expect(Parity::Backup).
+      to have_received(:new).
+      with(
+        from: "production",
+        to: "staging",
+        additional_args: "--confirm parity-integration-staging",
+      )
+    expect(backup).to have_received(:restore)
+  end
+
+  it "correctly connects to the Heroku app when the $PWD's name does not match the app's name (remote uses https:// protocol)" do
+    backup = stub_parity_backup
+    stub_git_remote_for_https(
+      base_name: "parity-integration",
+      environment: "staging",
+    )
     allow(Parity::Backup).to receive(:new).and_return(backup)
 
     Parity::Environment.new("staging", ["restore", "production"]).run
@@ -349,6 +369,16 @@ RSpec.describe Parity::Environment do
     git_remote = instance_double(
       "Git::Remote",
       url: "git@heroku.com:#{base_name}-#{environment}.git",
+    )
+    git = instance_double("Git::Base")
+    allow(git).to receive(:remote).with("staging").and_return(git_remote)
+    allow(Git).to receive(:init).and_return(git)
+  end
+
+  def stub_git_remote_for_https(base_name: "parity", environment: "staging")
+    git_remote = instance_double(
+      "Git::Remote",
+      url: "https://git.heroku.com/#{base_name}-#{environment}.git",
     )
     git = instance_double("Git::Base")
     allow(git).to receive(:remote).with("staging").and_return(git_remote)


### PR DESCRIPTION
In 10574fe we began using the Git remote address to determine the name
of the Heroku application. The change did not correctly handle Git
remotes that use the HTTPS protocol, which Heroku supports.

This change updates the address parsing to handle both `git://` and
`https://` remotes.