### PR TITLE
[blocked by #97] Don't install executables via Rubygems

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -1,0 +1,16 @@
+##################################################
+#  NOTE FOR UPGRADING FROM 0.9.3 OR EARLIER      #
+##################################################
+
+As of version 1.0.0, Parity no longer distributes its executables via Rubygems.
+
+If you use apt or Homebrew to install dependencies, you can install Parity
+through those package managers to get the `development`, `staging`, and
+`production` executables. Installing the executables via package manager makes
+the programs available across Ruby versions.
+
+Users without access to those package managers or who prefer to self-install can
+find the executables at our Github repository:
+
+https://github.com/thoughtbot/parity
+

--- a/parity.gemspec
+++ b/parity.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |spec|
   eos
 
   spec.email = ["dan@thoughtbot.com"]
-  spec.executables = ["development", "staging", "production"]
   spec.files = `git ls-files -- lib/* README.md`.split("\n")
   spec.homepage = "https://github.com/thoughtbot/parity"
   spec.license = "MIT"

--- a/parity.gemspec
+++ b/parity.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.summary = "Shell commands for development, staging, and production parity."
   spec.version = Parity::VERSION
+
+  spec.post_install_message = File.read("UPGRADING")
 end


### PR DESCRIPTION
Rubygems should be used to install dependencies, not to distribute
command-line tools (other than perhaps those highly-coupled to a
specific Ruby version). Our packaging with Travelling Ruby allows us to
distribute Parity via popular package managers or for users to compile
and install locally.

This change removes the gemspec statement that installs the
`development`, `production`, and `staging` executables through Rubygems.
Those files remain available in packaging, and will be installed by apt
and Homebrew.

Close #77.