### PR TITLE
README - Add remotes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,13 @@ Parity expects:
 
 * A `staging` remote pointing to the staging Heroku app.
 * A `production` remote pointing to the production Heroku app.
+```
+heroku git:remote -r staging -a your-staging-app
+heroku git:remote -r production -a your-production-app
+```
 * There is a `config/database.yml` file that can be parsed as YAML for
   `['development']['database']`.
+
 
 Customization
 -------------


### PR DESCRIPTION
## Documentation Update
Updated the README to give an example of adding remotes to Heroku. Thought it would be nice to see an example here to prevent someone from having to look it up.