### PR TITLE
Use `Kernel.exec` for long-running processes

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -33,7 +33,7 @@ module Parity
     end
 
     def run_via_cli
-      Kernel.system("heroku", subcommand, *arguments, "--remote", environment)
+      Kernel.exec("heroku", subcommand, *arguments, "--remote", environment)
     end
 
     def backup

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -2,6 +2,7 @@ require File.join(File.dirname(__FILE__), '..', '..', 'lib', 'parity')
 
 RSpec.describe Parity::Environment do
   before do
+    allow(Kernel).to receive(:exec).and_return(true)
     allow(Kernel).to receive(:system).and_return(true)
   end
 
@@ -11,11 +12,11 @@ RSpec.describe Parity::Environment do
       ["pg:psql", "-c", "select count(*) from users;"],
     ).run
 
-    expect(Kernel).to have_received(:system).with(*psql_count)
+    expect(Kernel).to have_received(:exec).with(*psql_count)
   end
 
   it "returns `false` when a system command fails" do
-    allow(Kernel).to receive(:system).with(*psql_count).and_return(nil)
+    allow(Kernel).to receive(:exec).with(*psql_count).and_return(nil)
 
     result = Parity::Environment.new(
       "production",
@@ -186,7 +187,7 @@ RSpec.describe Parity::Environment do
   it "opens the app" do
     Parity::Environment.new("production", ["open"]).run
 
-    expect(Kernel).to have_received(:system).with(*open)
+    expect(Kernel).to have_received(:exec).with(*open)
   end
 
   it "opens a Redis session connected to the environment's Redis service" do


### PR DESCRIPTION
In #79, @bernerdschaefer raised the issue that for long-running
processes like log-tailing and consoles that parity was responding to
Control-C and terminating the process rather than letting the remote
session handle the input.

This change updates `Environment#run_via_cli` to use `Kernel.exec`
rather than `Kernel.system`, which replaces the current process with the
desired command. We aren't replacing all uses of `Kernel.system`, as
some of our commands are multi-step and would not successfully complete
if interrupted by an non-final command being invoked though `exec`. This
solution should give better results for consoles and other long-running
tasks.

http://ruby-doc.org/core-2.3.1/Kernel.html#method-i-exec

Close #79.