### PR TITLE
Check migration diff in HEAD when running in non production environment

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -156,9 +156,10 @@ module Parity
     end
 
     def pending_migrations?
+      branch_to_compare = production? ? 'master' : 'HEAD'
       !Kernel.system(%{
         git fetch #{environment} &&
-        git diff --quiet #{environment}/master..master -- db/migrate
+        git diff --quiet #{environment}/master..#{branch_to_compare} -- db/migrate
       })
     end
 

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -156,11 +156,18 @@ module Parity
     end
 
     def pending_migrations?
-      compare_with = production? ? "master" : "HEAD"
       !Kernel.system(%{
         git fetch #{environment} &&
         git diff --quiet #{environment}/master..#{compare_with} -- db/migrate
       })
+    end
+    
+    def compare_with
+      if production?
+        "master"
+      else
+        "HEAD"
+      end
     end
 
     def methodized_subcommand

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -156,10 +156,10 @@ module Parity
     end
 
     def pending_migrations?
-      branch_to_compare = production? ? 'master' : 'HEAD'
+      compare_with = production? ? "master" : "HEAD"
       !Kernel.system(%{
         git fetch #{environment} &&
-        git diff --quiet #{environment}/master..#{branch_to_compare} -- db/migrate
+        git diff --quiet #{environment}/master..#{compare_with} -- db/migrate
       })
     end
 


### PR DESCRIPTION
When one is deploying from any other branch than master comparison must be done with current HEAD otherwise migrations are always run when they are only in current local branch and not yet in local master.