### PR TITLE
Feature/adds dockerized development support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ heroku git:remote -r production -a your-production-app
 * There is a `config/database.yml` file that can be parsed as YAML for
   `['development']['database']`.
 
+* For dockerized apps, there is a `docker-compose.yml` file with a service called `db` for your postgres database and you mounted /tmp folder.
+
 
 Customization
 -------------

--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -27,10 +27,14 @@ module Parity
     private
 
     def restore_from_development
-      Kernel.system(
-        "heroku pg:push #{development_db} DATABASE_URL --remote #{to} "\
-          "#{additional_args}",
-      )
+      if dockerized_app?
+        $stdout.puts "Parity does not support restoring backups from a dockerized development"
+      else 
+        Kernel.system(
+          "heroku pg:push #{development_db} DATABASE_URL --remote #{to} "\
+            "#{additional_args}",
+        )
+      end
     end
 
     def restore_to_development
@@ -41,7 +45,12 @@ module Parity
     end
 
     def wipe_development_database
-      Kernel.system("dropdb #{development_db} && createdb #{development_db}")
+      if dockerized_app?
+        Kernel.system("docker-compose exec db dropdb -U postgres #{development_db}")
+        Kernel.system("docker-compose exec db createdb -U postgres #{development_db}")
+      else
+        Kernel.system("dropdb #{development_db} && createdb #{development_db}")
+      end
     end
 
     def download_remote_backup
@@ -51,10 +60,16 @@ module Parity
     end
 
     def restore_from_local_temp_backup
-      Kernel.system(
-        "pg_restore tmp/latest.backup --verbose --clean --no-acl --no-owner "\
-          "-d #{development_db} #{additional_args}",
-      )
+      command = if dockerized_app?
+                  "docker-compose exec db "\
+                    "pg_restore -U postgres tmp/latest.backup --verbose --clean --no-acl --no-owner "\
+                      "-d #{development_db} #{additional_args}"
+                else
+                  "pg_restore tmp/latest.backup --verbose --clean --no-acl --no-owner "\
+                    "-d #{development_db} #{additional_args}"
+                end
+
+      Kernel.system(command)
     end
 
     def delete_local_temp_backup
@@ -84,6 +99,10 @@ module Parity
 
     def database_yaml_file
       IO.read(DATABASE_YML_RELATIVE_PATH)
+    end
+
+    def dockerized_app?
+      File.exists?("docker-compose.yml")
     end
   end
 end

--- a/spec/parity/backup_spec.rb
+++ b/spec/parity/backup_spec.rb
@@ -21,6 +21,30 @@ describe Parity::Backup do
       with(delete_local_temp_backup_command)
   end
 
+  it "restores backups to dockerized development (after dropping the development DB)" do
+    allow(IO).to receive(:read).and_return(database_fixture)
+    allow(File).to receive(:exists?).and_return(docker_compose_fixture)
+    allow(Kernel).to receive(:system)
+
+    Parity::Backup.new(from: "production", to: "development").restore
+
+    expect(Kernel).
+      to have_received(:system).
+      with(download_remote_database_command)
+    expect(Kernel).
+      to have_received(:system).
+      with(drop_dockerized_development_database_drop_command)
+    expect(Kernel).
+      to have_received(:system).
+      with(create_dockerized_development_database_create_command)
+    expect(Kernel).
+      to have_received(:system).
+      with(dockerized_restore_from_local_temp_backup_command)
+    expect(Kernel).
+      to have_received(:system).
+      with(delete_local_temp_backup_command)
+  end
+
   it "restores backups to staging from production" do
     allow(Kernel).to receive(:system)
 
@@ -59,6 +83,10 @@ describe Parity::Backup do
     IO.read(fixture_path("database.yml"))
   end
 
+  def docker_compose_fixture
+    File.exists?(fixture_path("docker-compose.yml"))
+  end
+
   def database_with_erb_fixture
     IO.read(fixture_path("database_with_erb.yml"))
   end
@@ -71,8 +99,22 @@ describe Parity::Backup do
     "dropdb #{db_name} && createdb #{db_name}"
   end
 
+  def drop_dockerized_development_database_drop_command(db_name: default_db_name)
+    "docker-compose exec db dropdb -U postgres #{db_name}"
+  end
+
+  def create_dockerized_development_database_create_command(db_name: default_db_name)
+    "docker-compose exec db createdb -U postgres #{db_name}"
+  end
+
   def download_remote_database_command
     'curl -o tmp/latest.backup "$(production pg:backups public-url -q)"'
+  end
+
+  def dockerized_restore_from_local_temp_backup_command
+    "docker-compose exec db "\
+     "pg_restore -U postgres tmp/latest.backup --verbose --clean --no-acl --no-owner "\
+      "-d #{default_db_name} "
   end
 
   def restore_from_local_temp_backup_command


### PR DESCRIPTION
### What does this PR do?
* Adds capability to restore staging or production databases into development in a dockerized project

I have a dockerized project, staging and production were working excellent for me but I could not use development because postgres commands were being executed locally, not inside the container.

With these changes I am able to restore production's, or staging's, database into dockerized development.

Restore dockerized development database into staging or production is pending, I will try to address it, it would be great to have. 