### PR TITLE
Run pg_restore using multiple concurrent jobs

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -1,3 +1,5 @@
+require "etc"
+
 module Parity
   class Backup
     BLANK_ARGUMENTS = "".freeze
@@ -53,7 +55,8 @@ module Parity
     def restore_from_local_temp_backup
       Kernel.system(
         "pg_restore tmp/latest.backup --verbose --clean --no-acl --no-owner "\
-          "-d #{development_db} #{additional_args}",
+          "--dbname #{development_db} --jobs #{Etc.nprocessors} "\
+          "#{additional_args}",
       )
     end
 

--- a/parity.gemspec
+++ b/parity.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.name = "parity"
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = ">= 2.2.0"
   spec.summary = "Shell commands for development, staging, and production parity."
   spec.version = Parity::VERSION
 

--- a/spec/parity/backup_spec.rb
+++ b/spec/parity/backup_spec.rb
@@ -4,6 +4,7 @@ describe Parity::Backup do
   it "restores backups to development (after dropping the development DB)" do
     allow(IO).to receive(:read).and_return(database_fixture)
     allow(Kernel).to receive(:system)
+    allow(Etc).to receive(:nprocessors).and_return(number_of_processes)
 
     Parity::Backup.new(from: "production", to: "development").restore
 
@@ -77,7 +78,11 @@ describe Parity::Backup do
 
   def restore_from_local_temp_backup_command
     "pg_restore tmp/latest.backup --verbose --clean --no-acl --no-owner "\
-      "-d #{default_db_name} "
+      "--dbname #{default_db_name} --jobs #{number_of_processes} "
+  end
+
+  def number_of_processes
+    2
   end
 
   def delete_local_temp_backup_command


### PR DESCRIPTION
> Run the most time-consuming parts of pg_restore — those which load
> data, create indexes, or create constraints — using multiple
> concurrent jobs. This option can dramatically reduce the time to
> restore a large database to a server running on a multiprocessor
> machine.

> Each job is one process or one thread, depending on the operating
> system, and uses a separate connection to the server.

> The optimal value for this option depends on the hardware setup of the
> server, of the client, and of the network. Factors include the number
> of CPU cores and the disk setup. A good place to start is the number
> of CPU cores on the server, but values larger than that can also lead
> to faster restore times in many cases. Of course, values that are too
> high will lead to decreased performance because of thrashing.

> Only the custom archive format is supported with this option. The
> input file must be a regular file (not, for example, a pipe). This
> option is ignored when emitting a script rather than connecting
> directly to a database server. Also, multiple jobs cannot be used
> together with the option --single-transaction.

https://www.postgresql.org/docs/9.2/static/app-pgrestore.html