### PR TITLE
fix/ add-heroku-pg-updates

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -48,7 +48,7 @@ module Parity
 
     def download_remote_backup
       Kernel.system(
-        "curl -o tmp/latest.backup \"$(heroku pg:backups:url -- remote #{from})\"",
+        "curl -o tmp/latest.backup \"$(heroku pg:backups:url --remote #{from})\"",
       )
     end
 
@@ -63,10 +63,10 @@ module Parity
     def delete_local_temp_backup
       Kernel.system("rm tmp/latest.backup")
     end
-rake
+
     def restore_to_remote_environment
       Kernel.system(
-        "heroku pg:backups restore #{backup_from} --remote #{to} "\
+        "heroku pg:backups:restore #{backup_from} --remote #{to} "\
           "#{additional_args}",
       )
     end
@@ -76,7 +76,7 @@ rake
     end
 
     def remote_db_backup_url
-      "heroku pg:backups public-url --remote #{from}"
+      "heroku pg:backups:url --remote #{from}"
     end
 
     def development_db

--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -48,7 +48,7 @@ module Parity
 
     def download_remote_backup
       Kernel.system(
-        "curl -o tmp/latest.backup \"$(#{from} pg:backups public-url -q)\"",
+        "curl -o tmp/latest.backup \"$(heroku pg:backups:url -- remote #{from})\"",
       )
     end
 
@@ -63,7 +63,7 @@ module Parity
     def delete_local_temp_backup
       Kernel.system("rm tmp/latest.backup")
     end
-
+rake
     def restore_to_remote_environment
       Kernel.system(
         "heroku pg:backups restore #{backup_from} --remote #{to} "\

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -35,7 +35,7 @@ module Parity
     end
 
     def backup
-      Kernel.system("heroku pg:backups capture --remote #{environment}")
+      Kernel.system("heroku pg:backups:capture --remote #{environment}")
     end
 
     def deploy
@@ -161,7 +161,7 @@ module Parity
         git diff --quiet #{environment}/master..#{compare_with} -- db/migrate
       })
     end
-    
+
     def compare_with
       if production?
         "master"

--- a/spec/parity/backup_spec.rb
+++ b/spec/parity/backup_spec.rb
@@ -73,7 +73,7 @@ describe Parity::Backup do
   end
 
   def download_remote_database_command
-    'curl -o tmp/latest.backup "$(production pg:backups public-url -q)"'
+    'curl -o tmp/latest.backup "$(heroku pg:backups:url --remote production)"'
   end
 
   def restore_from_local_temp_backup_command
@@ -94,12 +94,12 @@ describe Parity::Backup do
   end
 
   def heroku_production_to_staging_passthrough
-    "heroku pg:backups restore `heroku pg:backups public-url "\
+    "heroku pg:backups:restore `heroku pg:backups:url "\
       "--remote production` DATABASE --remote staging "
   end
 
   def additional_argument_pass_through
-    "heroku pg:backups restore `heroku pg:backups public-url "\
+    "heroku pg:backups:restore `heroku pg:backups:url "\
       "--remote production` DATABASE --remote staging "\
       "--confirm thisismyapp-staging"
   end

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe Parity::Environment do
   end
 
   def heroku_backup
-    "heroku pg:backups capture --remote production"
+    "heroku pg:backups:capture --remote production"
   end
 
   def heroku_console


### PR DESCRIPTION
### What does this PR do?

It looks like heroku has updated some `pg:backups` commands https://devcenter.heroku.com/articles/heroku-postgres-backups

* Updates heroku PG CLI commands as of 08/dec/2016
