### PR TITLE
Update backup command

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -48,7 +48,7 @@ module Parity
 
     def download_remote_backup
       Kernel.system(
-        "curl -o tmp/latest.backup \"$(#{from} pg:backups public-url -q)\"",
+        "curl -o tmp/latest.backup \"$(#{from} pg:backups:public-url -q)\"",
       )
     end
 

--- a/spec/parity/backup_spec.rb
+++ b/spec/parity/backup_spec.rb
@@ -73,7 +73,7 @@ describe Parity::Backup do
   end
 
   def download_remote_database_command
-    'curl -o tmp/latest.backup "$(production pg:backups public-url -q)"'
+    'curl -o tmp/latest.backup "$(production pg:backups:public-url -q)"'
   end
 
   def restore_from_local_temp_backup_command


### PR DESCRIPTION
Newest `heroku` expects a certain syntax: all commands separated by `:`.