### PR TITLE
Packaging: Remove Bundler from packaging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ RSpec::Core::RakeTask.new('spec')
 task default: :spec
 
 PROJECT_NAME = "parity"
-TRAVELING_RUBY_VERSION = "20150517-2.2.2"
+TRAVELING_RUBY_VERSION = "20150715-2.2.2"
 TRAVELING_RUBY_HOST = "http://d6r77u77i8pq3.cloudfront.net/releases"
 RUBY_BASENAME = "traveling-ruby-#{TRAVELING_RUBY_VERSION}"
 
@@ -59,8 +59,6 @@ def create_package(target)
   package_dir = "#{PROJECT_NAME}-#{Parity::VERSION}-#{target}"
 
   copy_lib(package_dir)
-  copy_vendored_gems(package_dir)
-  copy_bundler_config(package_dir)
   copy_binaries(package_dir)
   copy_shims(package_dir)
   extract_ruby(package_dir, target)
@@ -83,24 +81,6 @@ def copy_lib(package_dir)
 
   cp_r "lib", app_dir
   cp "README.md", app_dir
-end
-
-def copy_bundler_config(package_dir)
-  vendor_path = "#{package_dir}/lib/vendor"
-  bundle_path = "#{vendor_path}/.bundle"
-  mkdir_p bundle_path
-
-  cp "Gemfile", vendor_path
-  cp "Gemfile.lock", vendor_path
-  chmod "+w", "#{vendor_path}/Gemfile.lock"
-  cp "packaging/bundler-config", "#{bundle_path}/config"
-end
-
-def copy_vendored_gems(package_dir)
-  lib_path = "#{package_dir}/lib"
-  mkdir_p lib_path
-
-  cp_r "packaging/vendor", lib_path
 end
 
 def copy_binaries(package_dir)

--- a/lib/parity/version.rb
+++ b/lib/parity/version.rb
@@ -1,3 +1,3 @@
 module Parity
-  VERSION = "2.0.0".freeze
+  VERSION = "2.0.1".freeze
 end

--- a/packaging/development_shim.sh
+++ b/packaging/development_shim.sh
@@ -4,10 +4,6 @@ set -e
 
 REALPATH=$(readlink $0 || $0)
 RELATIVE_DIR=$(dirname $REALPATH)
-SELF_DIR=$(cd $(dirname $0) && cd $RELATIVE_DIR/.. && pwd)
+SELF_DIR=$(cd $(dirname $0) && cd $RELATIVE_DIR && pwd)
 
-# Tell Bundler where the Gemfile and gems are.
-export BUNDLE_GEMFILE="$(echo $SELF_DIR)/lib/vendor/Gemfile"
-unset BUNDLE_IGNORE_CONFIG
-
-exec "$SELF_DIR/lib/ruby/bin/ruby" -rbundler/setup "$SELF_DIR/lib/app/bin/development" "$@"
+exec "$SELF_DIR/../lib/ruby/bin/ruby" "$SELF_DIR/../lib/app/bin/development" "$@"

--- a/packaging/production_shim.sh
+++ b/packaging/production_shim.sh
@@ -4,10 +4,6 @@ set -e
 
 REALPATH=$(readlink $0 || $0)
 RELATIVE_DIR=$(dirname $REALPATH)
-SELF_DIR=$(cd $(dirname $0) && cd $RELATIVE_DIR/.. && pwd)
+SELF_DIR=$(cd $(dirname $0) && cd $RELATIVE_DIR && pwd)
 
-# Tell Bundler where the Gemfile and gems are.
-export BUNDLE_GEMFILE="$(echo $SELF_DIR)/lib/vendor/Gemfile"
-unset BUNDLE_IGNORE_CONFIG
-
-exec "$SELF_DIR/lib/ruby/bin/ruby" -rbundler/setup "$SELF_DIR/lib/app/bin/production" "$@"
+exec "$SELF_DIR/../lib/ruby/bin/ruby" "$SELF_DIR/../lib/app/bin/production" "$@"

--- a/packaging/staging_shim.sh
+++ b/packaging/staging_shim.sh
@@ -4,10 +4,6 @@ set -e
 
 REALPATH=$(readlink $0 || $0)
 RELATIVE_DIR=$(dirname $REALPATH)
-SELF_DIR=$(cd $(dirname $0) && cd $RELATIVE_DIR/.. && pwd)
+SELF_DIR=$(cd $(dirname $0) && cd $RELATIVE_DIR && pwd)
 
-# Tell Bundler where the Gemfile and gems are.
-export BUNDLE_GEMFILE="$(echo $SELF_DIR)/lib/vendor/Gemfile"
-unset BUNDLE_IGNORE_CONFIG
-
-exec "$SELF_DIR/lib/ruby/bin/ruby" -rbundler/setup "$SELF_DIR/lib/app/bin/staging" "$@"
+exec "$SELF_DIR/../lib/ruby/bin/ruby" "$SELF_DIR/../lib/app/bin/staging" "$@"


### PR DESCRIPTION
Traveling Ruby is no longer receiving updates, and is locked on a
version of Bundler that causes an update to `Gemfile.lock` when `bundle
install` is run on installed systems, which causes permission problems
on client users' machines.

We stopped using gem dependencies in Parity in 5704201, but still had
pieces of our packaging that were there solely to support gem
dependencies.

This change brings our Rakefile back to the original setup for Traveling
Ruby by @joelq in 7916985 along with @gabebw's shim fixes in 89be4ad. We
still plan to migrate away from Traveling Ruby, but these changes are
needed to get a valid, working packaged version of Parity on client
machines to comply with the new Heroku CLI format.

One update has been made since those prior Rakefile and shim versions,
which is to update Traveling Ruby to use version 2.2.2 as of 2015-07-15,
as it contains security vulnerability fixes not present in prior
versions.