### PR TITLE
Add lib to load path for parity and require parity

### DIFF
--- a/bin/development
+++ b/bin/development
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
-require File.join(File.dirname(__FILE__), '..', 'lib', 'parity')
+$LOAD_PATH.unshift File.expand_path(File.join("..", "..", "lib"), __FILE__)
+require "parity"
 
 if ARGV.empty?
   puts Parity::Usage.new

--- a/bin/production
+++ b/bin/production
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
-require File.join(File.dirname(__FILE__), '..', 'lib', 'parity')
+$LOAD_PATH.unshift File.expand_path(File.join("..", "..", "lib"), __FILE__)
+require "parity"
 
 if ARGV.empty?
   puts Parity::Usage.new

--- a/bin/staging
+++ b/bin/staging
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
-require File.join(File.dirname(__FILE__), '..', 'lib', 'parity')
+$LOAD_PATH.unshift File.expand_path(File.join("..", "..", "lib"), __FILE__)
+require "parity"
 
 if ARGV.empty?
   puts Parity::Usage.new


### PR DESCRIPTION
Rather than explicitly requiring the path that assumes the current project directory, it tries to add the necessary directory to the load path and requiring the library after. This maintains previous behavior,
but takes advantage of everything available in the load path in case the lib directory is not in the stated location, but is nonetheless known in the load path. 

For example, this happens in the aptitude package manager on Debian, where bin files might be located in the `/usr/bin` directory but the `lib/parity` files are located in `/usr/lib/ruby` directory