### PR TITLE
Fix production restoration command

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -80,7 +80,7 @@ module Parity
     end
 
     def additional_restore_arguments
-      (arguments.drop(1) + [restore_confirmation_argument]).
+      (arguments.drop(1) - ["--force"] + [restore_confirmation_argument]).
         compact.
         join(" ")
     end

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Parity::Environment do
     Parity::Environment.new("production", ["restore", "staging", "--force"]).run
 
     expect(Parity::Backup).to have_received(:new).
-      with(from: "staging", to: "production", additional_args: "--force")
+      with(from: "staging", to: "production", additional_args: "")
     expect(backup).to have_received(:restore)
   end
 


### PR DESCRIPTION
Why:

* Parity::Environment requires that `--forced` must be provided in order
  to allow restoring the production database from a local backup, but it
  is also passing that argument to Heroku CLI, which fails due to an
  unexpected flag (see image below). Issue tested with:
  - heroku-toolbelt/3.43.13 (x86_64-linux)
  - heroku-cli/5.7.5-18ff676 (linux-amd64)

![parity](https://cloud.githubusercontent.com/assets/1141870/24162316/00253612-0e5f-11e7-866e-cbfe9be20542.png)

This change addresses the issue by:

* Refactoring Parity::Environment to explicitly exclude `--force` from
  the list of arguments passed to Heroku CLI.