### PR TITLE
Heroku-CLI change: don't pass `--confirm` to `pg:push`

### DIFF
--- a/lib/parity.rb
+++ b/lib/parity.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH << File.expand_path("..", __FILE__)
 
+require "parity/heroku_app_name"
 require "parity/version"
 require "parity/environment"
 require "parity/usage"

--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -22,13 +22,12 @@ module Parity
       end
     end
 
-    protected
+    private
 
     attr_reader :additional_args, :from, :to
 
-    private
-
     def restore_from_development
+      reset_remote_database
       Kernel.system(
         "heroku pg:push #{development_db} DATABASE_URL --remote #{to} "\
           "#{additional_args}",
@@ -44,6 +43,17 @@ module Parity
 
     def wipe_development_database
       Kernel.system("dropdb #{development_db} && createdb #{development_db}")
+    end
+
+    def reset_remote_database
+      Kernel.system(
+        "heroku pg:reset --remote #{to} #{additional_args} "\
+          "--confirm #{heroku_app_name}",
+      )
+    end
+
+    def heroku_app_name
+      HerokuAppName.new(to).to_s
     end
 
     def download_remote_backup
@@ -65,6 +75,7 @@ module Parity
     end
 
     def restore_to_remote_environment
+      reset_remote_database
       Kernel.system(
         "heroku pg:backups:restore #{backup_from} --remote #{to} "\
           "#{additional_args}",

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -86,9 +86,13 @@ module Parity
     end
 
     def restore_confirmation_argument
-      unless PROTECTED_ENVIRONMENTS.include?(environment)
+      unless PROTECTED_ENVIRONMENTS.include?(environment) || from_development?
         "--confirm #{heroku_app_name}"
       end
+    end
+
+    def from_development?
+      arguments.first == "development"
     end
 
     def console
@@ -129,10 +133,7 @@ module Parity
     end
 
     def heroku_app_name
-      @heroku_app_name ||= Open3.
-        capture3(command_for_remote("info"))[0].
-        split("\n")[0].
-        gsub(/(\s|=)+/, "")
+      HerokuAppName.new(environment).to_s
     end
 
     def command_for_remote(command)

--- a/lib/parity/heroku_app_name.rb
+++ b/lib/parity/heroku_app_name.rb
@@ -1,0 +1,18 @@
+module Parity
+  class HerokuAppName
+    def initialize(environment)
+      @environment = environment
+    end
+
+    def to_s
+      @heroku_app_name ||= Open3.
+        capture3("heroku info --remote #{environment}")[0].
+        split("\n")[0].
+        gsub(/(\s|=)+/, "")
+    end
+
+    private
+
+    attr_reader :environment
+  end
+end

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -382,16 +382,14 @@ RSpec.describe Parity::Environment do
   end
 
   def stub_git_remote(base_name: "parity", environment: "staging")
-    allow(Open3).
-      to receive(:capture3).
-      with("heroku info --remote #{environment}").
-      and_return(
-        [
-          "=== #{base_name}-#{environment}\nAddOns: blahblahblah",
-          "",
-          {},
-        ],
-      )
+    heroku_app_name = instance_double(
+      Parity::HerokuAppName,
+      to_s: "#{base_name}-#{environment}",
+    )
+    allow(Parity::HerokuAppName).
+      to receive(:new).
+      with(environment).
+      and_return(heroku_app_name)
   end
 
   def stub_parity_backup

--- a/spec/parity/heroku_app_name_spec.rb
+++ b/spec/parity/heroku_app_name_spec.rb
@@ -1,0 +1,22 @@
+require File.join(File.dirname(__FILE__), "..", "..", "lib", "parity")
+
+RSpec.describe Parity::HerokuAppName do
+  describe "#to_s" do
+    it "returns the name of the application as hosted on Heroku" do
+      allow(Open3).
+        to receive(:capture3).
+        with("heroku info --remote staging").
+        and_return(
+          [
+            "=== my-special-app-staging\nAddOns: blahblahblah",
+            "",
+            {},
+          ],
+        )
+
+      application_name = Parity::HerokuAppName.new("staging").to_s
+
+      expect(application_name).to eq("my-special-app-staging")
+    end
+  end
+end


### PR DESCRIPTION
Heroku's `pg:push` CLI no longer accepts the `--confirm` argument, as it
expects the remote database to already be reset before overwriting it
with a backup.

Before restoring to a remote environment, we reset the remote database
with `pg:reset`. We will pass a confirm argument to `pg:reset`. To
accomplish this, the mechanism to determine the remote application name
(not the git remote) has been extracted into its own object.

Fix #128.