### PR TITLE
development restore: ensure a tmp directory exists

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -35,6 +35,7 @@ module Parity
     end
 
     def restore_to_development
+      ensure_temp_directory_exists
       download_remote_backup
       wipe_development_database
       restore_from_local_temp_backup
@@ -54,6 +55,10 @@ module Parity
 
     def heroku_app_name
       HerokuAppName.new(to).to_s
+    end
+
+    def ensure_temp_directory_exists
+      Kernel.system("mkdir -p tmp")
     end
 
     def download_remote_backup

--- a/spec/parity/backup_spec.rb
+++ b/spec/parity/backup_spec.rb
@@ -10,6 +10,9 @@ describe Parity::Backup do
 
     expect(Kernel).
       to have_received(:system).
+      with(make_temp_directory_command)
+    expect(Kernel).
+      to have_received(:system).
       with(download_remote_database_command)
     expect(Kernel).
       to have_received(:system).
@@ -88,6 +91,10 @@ describe Parity::Backup do
 
   def drop_development_database_drop_command(db_name: default_db_name)
     "dropdb #{db_name} && createdb #{db_name}"
+  end
+
+  def make_temp_directory_command
+    "mkdir -p tmp"
   end
 
   def download_remote_database_command


### PR DESCRIPTION
When restoring a remote backup to development, if an application doesn't
have a `tmp` folder (either because it wasn't in source control or the
app never has one), we can't download the backup file from Heroku.

This change uses `mkdir -p` to create the directory (if needed) before
downloading the backup to the local machine.

Close #130.