### PR TITLE
Version 2.2.1

### DIFF
--- a/lib/parity/version.rb
+++ b/lib/parity/version.rb
@@ -1,3 +1,3 @@
 module Parity
-  VERSION = "2.2.0".freeze
+  VERSION = "2.2.1".freeze
 end


### PR DESCRIPTION
Heroku Toolbelt has been replaced by / renamed to Heroku CLI.
It is installed with `brew install heroku`. See:

https://devcenter.heroku.com/articles/heroku-cli#macos

* Upgrade Ruby version for contributors.
* Update release documentation for contributors.

Related:

https://github.com/thoughtbot/laptop/commit/3b7845b849830033e87617b470d8dd64c925e732
https://github.com/thoughtbot/laptop/commit/0636eea1983af478037fd75a9519a92f9f18a81f