### PR TITLE
Use `--if-exists` option with `dropdb`

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -43,7 +43,9 @@ module Parity
     end
 
     def wipe_development_database
-      Kernel.system("dropdb #{development_db} && createdb #{development_db}")
+      Kernel.system(
+        "dropdb --if-exists #{development_db} && createdb #{development_db}",
+      )
     end
 
     def reset_remote_database

--- a/spec/parity/backup_spec.rb
+++ b/spec/parity/backup_spec.rb
@@ -90,7 +90,7 @@ describe Parity::Backup do
   end
 
   def drop_development_database_drop_command(db_name: default_db_name)
-    "dropdb #{db_name} && createdb #{db_name}"
+    "dropdb --if-exists #{db_name} && createdb #{db_name}"
   end
 
   def make_temp_directory_command


### PR DESCRIPTION
This change adds a flag to the `dropdb` command so that we don't issue
an error if the local development database doesn't exist when we try to
drop it. A notice is issued by PG, but execution will continue.

PG docs: https://www.postgresql.org/docs/9.3/static/app-dropdb.html

cc: #137