### PR TITLE
Allow pre-2.2 Rubies to execute `development restore`

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -72,7 +72,7 @@ module Parity
     def restore_from_local_temp_backup
       Kernel.system(
         "pg_restore tmp/latest.backup --verbose --clean --no-acl --no-owner "\
-          "--dbname #{development_db} --jobs #{Etc.nprocessors} "\
+          "--dbname #{development_db} --jobs #{processor_cores} "\
           "#{additional_args}",
       )
     end
@@ -105,6 +105,18 @@ module Parity
 
     def database_yaml_file
       IO.read(DATABASE_YML_RELATIVE_PATH)
+    end
+
+    def processor_cores
+      if ruby_version_over_2_2?
+        Etc.nprocessors
+      else
+        2
+      end
+    end
+
+    def ruby_version_over_2_2?
+      Etc.respond_to?(:nprocessors)
     end
   end
 end


### PR DESCRIPTION
In #143, we got a report that because `Etc.nprocessors` was not
implemented until Ruby 2.2 that Ruby 2.1 users were unable to execute
`development restore`, which leverages that method to determine how many
parallel processes to use when restoring the backup from the downloaded
dump.

This change implements a check to see if `Etc.nprocessors` is available.
In the event that it's not, we'll default to two parallel processes. We
will plan to sunset this change in July 2018, giving users on Ruby 2.1,
which has been EOLed, six months to move on.

Close #143.