### PR TITLE
Use redis-cli `-u` argument rather than splitting URL

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -113,17 +113,7 @@ module Parity
     end
 
     def redis_cli
-      url = URI(raw_redis_url)
-
-      Kernel.system(
-        "redis-cli",
-        "-h",
-        url.host,
-        "-p",
-        url.port.to_s,
-        "-a",
-        url.password
-      )
+      Kernel.system("redis-cli", "-u", raw_redis_url)
     end
 
     def raw_redis_url

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -177,12 +177,8 @@ RSpec.describe Parity::Environment do
 
     expect(Kernel).to have_received(:system).with(
       "redis-cli",
-      "-h",
-      "landshark.redistogo.com",
-      "-p",
-      "90210",
-      "-a",
-      "abcd1234efgh5678"
+      "-u",
+      open3_redis_url_fetch_result[0].strip,
     )
     expect(Open3).
       to have_received(:capture3).


### PR DESCRIPTION
This change updates the Redis subcommand to use `redis-cli`'s `-u`
argument, letting `redis-cli` parse the URL rather than parsing it into
pieces in Parity.

https://redis.io/topics/rediscli#host-port-password-and-database