### PR TITLE
Add `pr_app` executable for running Heroku CLI commands on review apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,21 +75,25 @@ Open a console:
 
     production console
     staging console
+    pr_app 1234 console
 
 Migrate a database and restart the dynos:
 
     production migrate
     staging migrate
+    pr_app 1234 migrate
 
 Tail a log:
 
     production tail
     staging tail
+    pr_app 1234 tail
 
 Use [redis-cli][2] with your `REDIS_URL` add-on:
 
     production redis-cli
     staging redis-cli
+    pr_app 1234 redis-cli
 
 The scripts also pass through, so you can do anything with them that you can do
 with `heroku ______ --remote staging` or `heroku ______ --remote production`:
@@ -112,6 +116,20 @@ heroku git:remote -r production -a your-production-app
 ```
 * There is a `config/database.yml` file that can be parsed as YAML for
   `['development']['database']`.
+
+Pipelines
+---------
+
+If you deploy review applications with Heroku pipelines, run commands against
+those applications with the `pr_app` command, followed by the PR number for your
+application:
+
+```
+pr_app 1234 console
+```
+
+This command assumes that your review applications have a name derived from the
+name of the application your `staging` Git remote points at.
 
 Customization
 -------------

--- a/bin/pr_app
+++ b/bin/pr_app
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift File.expand_path(File.join("..", "..", "lib"), __FILE__)
+require "open3"
+require "parity"
+
+if ARGV.empty?
+  puts Parity::Usage.new
+else
+  review_app_number = ARGV.first
+  staging_git_remote = Open3.capture3("git remote get-url staging")[0].strip
+  review_app_prefix = staging_git_remote.split("/").last.gsub(/\.git\Z/, "")
+
+  exit Parity::Environment.new(
+    "#{review_app_prefix}-#{review_app_number}",
+    ARGV.drop(1),
+    switch: "--app",
+  ).run
+end

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -2,10 +2,11 @@ require "parity/backup"
 
 module Parity
   class Environment
-    def initialize(environment, subcommands)
+    def initialize(environment, subcommands, app_argument: "--remote")
       self.environment = environment
       self.subcommand = subcommands[0]
       self.arguments = subcommands[1..-1]
+      self.app_argument = app_argument
     end
 
     def run
@@ -16,7 +17,7 @@ module Parity
 
     PROTECTED_ENVIRONMENTS = %w(development production)
 
-    attr_accessor :environment, :subcommand, :arguments
+    attr_accessor :app_argument, :environment, :subcommand, :arguments
 
     def run_command
       if self.class.private_method_defined?(methodized_subcommand)
@@ -31,11 +32,11 @@ module Parity
     end
 
     def run_via_cli
-      Kernel.exec("heroku", subcommand, *arguments, "--remote", environment)
+      Kernel.exec("heroku", subcommand, *arguments, app_argument, environment)
     end
 
     def backup
-      Kernel.system("heroku pg:backups:capture --remote #{environment}")
+      Kernel.system("heroku pg:backups:capture #{app_argument} #{environment}")
     end
 
     def deploy
@@ -137,7 +138,7 @@ module Parity
     end
 
     def command_for_remote(command)
-      "heroku #{command} --remote #{environment}"
+      "heroku #{command} #{app_argument} #{environment}"
     end
 
     def run_migrations?

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe Parity::Environment do
     expect(Kernel).to have_received(:exec).with(*psql_count)
   end
 
+  it "allows connection to applications by app name rather than Git remote" do
+    Parity::Environment.new(
+      "my-pipeline-pr-1234",
+      ["tail", "--ps", "web"],
+      app_argument: "--app",
+    ).run
+
+    expect(Kernel).to have_received(:system).with(tail_pr_app)
+  end
+
   it "returns `false` when a system command fails" do
     allow(Kernel).to receive(:exec).with(*psql_count).and_return(nil)
 
@@ -335,6 +345,10 @@ RSpec.describe Parity::Environment do
 
   def tail
     "heroku logs --tail --ps web --remote production"
+  end
+
+  def tail_pr_app
+    "heroku logs --tail --ps web --app my-pipeline-pr-1234"
   end
 
   def open


### PR DESCRIPTION
This change adds a `pr_app` executable that can be used to run commands
on a review application that is part of the same Heroku Pipeline as the
application on the `staging` Git remote. If you had a staging application
called `my-staging-app`, and a review application whose Heroku
application name was `my-staging-app-pr-1234`, you would tail the logs
with:

```shell
pr_app 1234 tail
```

Review applications don't get an automatic local Git remote, but because
they share a name with the staging application, we can leverage the
naming scheme to build up an app name.