### PR TITLE
Don't migrate on deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,11 @@ Push your local development database backup up to staging:
 
     staging restore development
 
-Deploy from master to production
-and migrate and restart the dynos if necessary:
+Deploy master to production:
 
     production deploy
 
-Deploy the current branch to staging or a feature branch
-and migrate and restart the dynos if necessary:
+Deploy the current branch to staging:
 
     staging deploy
 

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -40,14 +40,6 @@ module Parity
     end
 
     def deploy
-      skip_migrations = !run_migrations?
-
-      if deploy_to_heroku
-        skip_migrations || migrate
-      end
-    end
-
-    def deploy_to_heroku
       if production?
         Kernel.system("git push production master")
       else
@@ -129,29 +121,6 @@ module Parity
 
     def command_for_remote(command)
       "heroku #{command} #{app_argument} #{environment}"
-    end
-
-    def run_migrations?
-      rails_app? && pending_migrations?
-    end
-
-    def rails_app?
-      has_rakefile? && has_migrations_folder?
-    end
-
-    def has_migrations_folder?
-      Pathname.new("db").join("migrate").directory?
-    end
-
-    def has_rakefile?
-      File.exists?("Rakefile")
-    end
-
-    def pending_migrations?
-      !Kernel.system(%{
-        git fetch #{environment} &&
-        git diff --quiet #{environment}/master..#{compare_with} -- db/migrate
-      })
     end
 
     def compare_with


### PR DESCRIPTION
This change removes code that automatically runs migrations on
deployment. Heroku's recommended approach for automatic migrations on
deploy is to use [Release Phase] tasks, which avoids an unnecessary
application restart (the app launch is after the release phase is run).
Applications that can't use release phase tasks for deployment can use a
`bin/deploy` script similar to the one included in [Suspenders].

This approach removes some Rails-specific code, which brings Parity closer to
being less-Rails focused (the only remaining Rails-specific commands
would be `migrate` and `console`). As a breaking change, this commit would
require a major version bump in its first release.

Fix #104
cc: #115

[Release Phase]: https://devcenter.heroku.com/articles/release-phase
[Suspenders]: https://github.com/thoughtbot/suspenders/blob/8c39efccac0fad8e6b74d25ff3a8809dd2f7df00/templates/bin_deploy