### PR TITLE
Fix incorrect argument for parallel restore jobs

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -72,7 +72,7 @@ module Parity
     def restore_from_local_temp_backup
       Kernel.system(
         "pg_restore tmp/latest.backup --verbose --clean --no-acl --no-owner "\
-          "--dbname #{development_db} --jobs #{processor_cores} "\
+          "--dbname #{development_db} --jobs=#{processor_cores} "\
           "#{additional_args}",
       )
     end

--- a/spec/parity/backup_spec.rb
+++ b/spec/parity/backup_spec.rb
@@ -127,7 +127,7 @@ describe Parity::Backup do
 
   def restore_from_local_temp_backup_command(cores: number_of_processes)
     "pg_restore tmp/latest.backup --verbose --clean --no-acl --no-owner "\
-      "--dbname #{default_db_name} --jobs #{cores} "
+      "--dbname #{default_db_name} --jobs=#{cores} "
   end
 
   def number_of_processes


### PR DESCRIPTION
This change fixes an issue where we were using the wrong argument format
to declare the number of parallel PG restore workers when restoring a
database to development. The `--jobs` argument requires an equals sign.

https://www.postgresql.org/docs/9.2/static/app-pgrestore.html

Co-authored-by: Devin Morgenstern <devin.morgenstern@protonmail.com>