### PR TITLE
Remove unused methods

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -123,14 +123,6 @@ module Parity
       "heroku #{command} #{app_argument} #{environment}"
     end
 
-    def compare_with
-      if production?
-        "master"
-      else
-        "HEAD"
-      end
-    end
-
     def methodized_subcommand
       subcommand.gsub("-", "_").to_sym
     end

--- a/spec/parity/backup_spec.rb
+++ b/spec/parity/backup_spec.rb
@@ -105,10 +105,6 @@ describe Parity::Backup do
     IO.read(fixture_path("database.yml"))
   end
 
-  def database_with_erb_fixture
-    IO.read(fixture_path("database_with_erb.yml"))
-  end
-
   def fixture_path(filename)
     File.join(File.dirname(__FILE__), "..", "fixtures", filename)
   end
@@ -136,10 +132,6 @@ describe Parity::Backup do
 
   def delete_local_temp_backup_command
     "rm tmp/latest.backup"
-  end
-
-  def heroku_staging_app_info_command
-    "heroku info --remote staging"
   end
 
   def heroku_development_to_staging_passthrough(db_name: default_db_name)

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -251,10 +251,6 @@ RSpec.describe Parity::Environment do
     ["heroku", "open", "--remote", "production"]
   end
 
-  def redis_cli
-    "redis-cli -h landshark.redistogo.com -p 90210 -a abcd1234efgh5678"
-  end
-
   def fetch_redis_url(env_variable)
     "heroku config:get #{env_variable} --remote production"
   end
@@ -273,22 +269,6 @@ RSpec.describe Parity::Environment do
       "-c", "select count(*) from users;",
       "--remote", "production"
     ]
-  end
-
-  def stub_is_a_rails_app
-    stub_rakefile_check(true)
-    stub_migration_path_check(true)
-  end
-
-  def stub_rakefile_check(result)
-    allow(File).to receive(:exists?).with("Rakefile").and_return(result)
-  end
-
-  def stub_migration_path_check(result)
-    path_stub = spy("Pathname", directory?: result)
-    allow(Pathname).to receive(:new).with("db").and_return(path_stub)
-
-    path_stub
   end
 
   def stub_git_remote(base_name: "parity", environment: "staging")


### PR DESCRIPTION
We had some private and spec helper method cruft left over from removed
features or changed implementations. This commit removes them.