### PR TITLE
Update ar_internal_metadata after remote restore

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -40,6 +40,7 @@ module Parity
       wipe_development_database
       restore_from_local_temp_backup
       delete_local_temp_backup
+      delete_rails_production_environment_settings
     end
 
     def wipe_development_database
@@ -79,6 +80,17 @@ module Parity
 
     def delete_local_temp_backup
       Kernel.system("rm tmp/latest.backup")
+    end
+
+    def delete_rails_production_environment_settings
+      Kernel.system(
+        "psql #{development_db} -c "\
+          "\"DO $$ BEGIN IF EXISTS "\
+          "(SELECT 1 FROM pg_tables WHERE tablename = 'ar_internal_metadata') "\
+          "THEN UPDATE ar_internal_metadata "\
+          "SET value = 'development' "\
+          "WHERE key = 'environment'; ELSE END IF; END $$;\"",
+      )
     end
 
     def restore_to_remote_environment


### PR DESCRIPTION
This change updates the local development restore operation to update the
`ar_internal_metadata` table if it's present, setting the environment
value to `development`.

Previously, failing to update the environment metadata would result in a potentially alarming error that might cause users to believe they were about to perform a destructive operation against their production database when what was actually happening was that the development database was a snapshot taken from production.

If the table is not present (either for older Rails applications or
non-Rails applications), this anonymous PG function will no-op.

Fix #147