### PR TITLE
Use different approach for marking `ar_internal_metadata` on restore

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -83,14 +83,9 @@ module Parity
     end
 
     def delete_rails_production_environment_settings
-      Kernel.system(
-        "psql #{development_db} -c "\
-          "\"DO $$ BEGIN IF EXISTS "\
-          "(SELECT 1 FROM pg_tables WHERE tablename = 'ar_internal_metadata') "\
-          "THEN UPDATE ar_internal_metadata "\
-          "SET value = 'development' "\
-          "WHERE key = 'environment'; ELSE END IF; END $$;\"",
-      )
+      Kernel.system(<<-SHELL)
+        psql #{development_db} -c "CREATE TABLE IF NOT EXISTS public.ar_internal_metadata (key character varying NOT NULL, value character varying, created_at timestamp without time zone NOT NULL, updated_at timestamp without time zone NOT NULL, CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key)); UPDATE ar_internal_metadata SET value = 'development' WHERE key = 'environment'"
+      SHELL
     end
 
     def restore_to_remote_environment

--- a/spec/parity/backup_spec.rb
+++ b/spec/parity/backup_spec.rb
@@ -185,11 +185,8 @@ describe Parity::Backup do
   end
 
   def set_db_metadata_sql
-    "psql parity_development -c "\
-      "\"DO $$ BEGIN IF EXISTS "\
-      "(SELECT 1 FROM pg_tables WHERE tablename = 'ar_internal_metadata') "\
-      "THEN UPDATE ar_internal_metadata "\
-      "SET value = 'development' "\
-      "WHERE key = 'environment'; ELSE END IF; END $$;\""
+    <<-SHELL
+        psql parity_development -c "CREATE TABLE IF NOT EXISTS public.ar_internal_metadata (key character varying NOT NULL, value character varying, created_at timestamp without time zone NOT NULL, updated_at timestamp without time zone NOT NULL, CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key)); UPDATE ar_internal_metadata SET value = 'development' WHERE key = 'environment'"
+    SHELL
   end
 end


### PR DESCRIPTION
The previous attempt in e5e025a to mark the `ar_internal_metadata`
environment row as non-production does not work reliably. The change
here fixes the issue with a slightly more brute-force approach, but one
that does not require capabilities beyond pure SQL.

If the `ar_internal_metadata` table does not exist, we'll create a blank
one with no rows. The following update operation will no-op.