### PR TITLE
Fix pr_app executable

### DIFF
--- a/bin/pr_app
+++ b/bin/pr_app
@@ -12,8 +12,8 @@ else
   review_app_prefix = staging_git_remote.split("/").last.gsub(/\.git\Z/, "")
 
   exit Parity::Environment.new(
-    "#{review_app_prefix}-#{review_app_number}",
+    "#{review_app_prefix}-pr-#{review_app_number}",
     ARGV.drop(1),
-    switch: "--app",
+    app_argument: "--app",
   ).run
 end

--- a/lib/parity/version.rb
+++ b/lib/parity/version.rb
@@ -1,3 +1,3 @@
 module Parity
-  VERSION = "3.0.0".freeze
+  VERSION = "3.0.1.beta".freeze
 end

--- a/parity.gemspec
+++ b/parity.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   eos
 
   spec.email = ["ralph@thoughtbot.com"]
-  spec.executables = ["development", "staging", "production"]
+  spec.executables = ["development", "staging", "production", "pr_app"]
   spec.files = `git ls-files -- lib/* README.md`.split("\n")
   spec.homepage = "https://github.com/thoughtbot/parity"
   spec.license = "MIT"


### PR DESCRIPTION
The `pr_app` command was broken in two ways. First, it had a mismatching
argument name for the app/environment flag, resulting in an error
whenever it was called. Second, it was missing the `-pr-` as part of the
Heroku review app name, so it would never find the correct application.
These changes are hard to test with an executable vs. a more OO-based
piece of code, but this change was tested against a real application and
worked correctly.