### PR TITLE
Heroku truncates app name to create prefix

### DIFF
--- a/bin/pr_app
+++ b/bin/pr_app
@@ -9,7 +9,7 @@ if ARGV.empty?
 else
   review_app_number = ARGV.first
   staging_git_remote = Open3.capture3("git remote get-url staging")[0].strip
-  review_app_prefix = staging_git_remote.split("/").last.gsub(/\.git\Z/, "")
+  review_app_prefix = staging_git_remote.split("/").last.gsub(/\.git\Z/, "")[0, 22]
 
   exit Parity::Environment.new(
     "#{review_app_prefix}-pr-#{review_app_number}",


### PR DESCRIPTION
Heroku will truncate the name of your application to 22 characters before using it as your review app prefix.

Fixes #164