### PR TITLE
Use bundle exec when starting remote console

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -89,7 +89,7 @@ module Parity
     end
 
     def console
-      Kernel.system(command_for_remote("run rails console"))
+      Kernel.system(command_for_remote("run bundle exec rails console"))
     end
 
     def migrate

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Parity::Environment do
   end
 
   def heroku_console
-    "heroku run rails console --remote production"
+    "heroku run bundle exec rails console --remote production"
   end
 
   def git_push


### PR DESCRIPTION
The combination of Bundler 2, Heroku's Ruby buildpack, and Rails' own
binstubs for Rails 5.2 appears to cause a conflict when starting the
console for an application bundled with Bundler 2.x.

```
% production console
Running rails console on ⬢ app-production... up, run.5165 (Standard-1X)
You must use Bundler 2 or greater with this lockfile.
```

The solution is to invoke the console with `bundle exec`, which gets
around the mismatch of Bundler 1.x and 2.x and blocks the Rails console
from starting.