### PR TITLE
Allow passing arguments to `console` subcommand

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -89,7 +89,11 @@ module Parity
     end
 
     def console
-      Kernel.system(command_for_remote("run bundle exec rails console"))
+      Kernel.system(
+        command_for_remote(
+          "run bundle exec rails console #{arguments.join(' ')}",
+        ),
+      )
     end
 
     def migrate

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -162,6 +162,12 @@ RSpec.describe Parity::Environment do
     expect(Kernel).to have_received(:system).with(heroku_console)
   end
 
+  it "passes arguments to the console subcommand" do
+    Parity::Environment.new("production", ["console", "--sandbox"]).run
+
+    expect(Kernel).to have_received(:system).with(heroku_console_with_sandbox)
+  end
+
   it "automatically restarts processes when it migrates the database" do
     Parity::Environment.new("production", ["migrate"]).run
 
@@ -221,7 +227,11 @@ RSpec.describe Parity::Environment do
   end
 
   def heroku_console
-    "heroku run bundle exec rails console --remote production"
+    "heroku run bundle exec rails console  --remote production"
+  end
+
+  def heroku_console_with_sandbox
+    "heroku run bundle exec rails console --sandbox --remote production"
   end
 
   def git_push


### PR DESCRIPTION
The `console` subcommand can't take arguments, which prevents the easy
use of the `--sandbox` feature on staging and production consoles to
check things with confidence that production data isn't being
accidentally changed.

This change appends post-`console` arguments as arguments on Heroku.