### PR TITLE
Allow additional psql argument

### DIFF
--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -2,11 +2,17 @@ require "parity/backup"
 
 module Parity
   class Environment
-    def initialize(environment, subcommands, app_argument: "--remote")
+    def initialize(
+      environment,
+      subcommands,
+      app_argument: "--remote",
+      psql_argument: ""
+    )
       self.environment = environment
       self.subcommand = subcommands[0]
       self.arguments = subcommands[1..-1]
       self.app_argument = app_argument
+      self.psql_argument = psql_argument
     end
 
     def run
@@ -18,6 +24,7 @@ module Parity
     PROTECTED_ENVIRONMENTS = %w(development production)
 
     attr_accessor :app_argument, :environment, :subcommand, :arguments
+    attr_accessor :psql_argument
 
     def run_command
       if self.class.private_method_defined?(methodized_subcommand)
@@ -58,6 +65,7 @@ module Parity
           from: arguments.first,
           to: environment,
           additional_args: additional_restore_arguments,
+          psql_args: psql_argument,
         ).restore
       end
     end


### PR DESCRIPTION
Allows using parity with non-default pg config (non-socket, different host, different username, with password etc), e.g. in local docker container environment with pg as a linked service (specified in docker-compose.yml).

One can create a customized version of `development` bin file and do the following:

```diff
  #!/usr/bin/env ruby

  $LOAD_PATH.unshift File.expand_path(File.join("..", "..", "lib"), __FILE__)
  require "parity"

  if ARGV.empty?
    puts Parity::Usage.new
  else
+   psql_arg = "-h postgres -U postgres"
+   exit Parity::Environment.new('development', ARGV, psql_argument: psql_arg).run
-   exit Parity::Environment.new('development', ARGV).run
  end
```

combined with `PGPASSWORD` env variable to run pg command lines non-interactively.