### PR TITLE
Replace automatic parallelization of backup jobs with opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ with `heroku ______ --remote staging` or `heroku ______ --remote production`:
     watch production ps
     staging open
 
+You can optionally parallelize a DB restore by passing `--parallelize`
+as a flag to the `development` or `production` commands:
+```
+    development restore-from production --parallelize
+```
+
 [2]: http://redis.io/commands
 
 Convention

--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -10,6 +10,7 @@ module Parity
     def initialize(args)
       @from, @to = args.values_at(:from, :to)
       @additional_args = args[:additional_args] || BLANK_ARGUMENTS
+      @parallelize = args[:parallelize] || false
     end
 
     def restore
@@ -24,7 +25,9 @@ module Parity
 
     private
 
-    attr_reader :additional_args, :from, :to
+    attr_reader :additional_args, :from, :to, :parallelize
+
+    alias :parallelize? :parallelize
 
     def restore_from_development
       reset_remote_database
@@ -115,10 +118,10 @@ module Parity
     end
 
     def processor_cores
-      if ruby_version_over_2_2?
+      if parallelize? && ruby_version_over_2_2?
         Etc.nprocessors
       else
-        2
+        1
       end
     end
 

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -57,6 +57,7 @@ module Parity
         Backup.new(
           from: arguments.first,
           to: environment,
+          parallelize: parallelize?,
           additional_args: additional_restore_arguments,
         ).restore
       end
@@ -72,10 +73,13 @@ module Parity
       arguments.include?("--force")
     end
 
+    def parallelize?
+      arguments.include?("--parallelize")
+    end
+
     def additional_restore_arguments
-      (arguments.drop(1) - ["--force"] + [restore_confirmation_argument]).
-        compact.
-        join(" ")
+      (arguments.drop(1) - ["--force", "--parallelize"] +
+        [restore_confirmation_argument]).compact.join(" ")
     end
 
     def restore_confirmation_argument

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -6,6 +6,23 @@ RSpec.describe Parity::Environment do
     allow(Kernel).to receive(:system).and_return(true)
   end
 
+  it "restores in parallel when passed the --parallelize flag" do
+    backup = stub_parity_backup
+    allow(Parity::Backup).to receive(:new).and_return(backup)
+
+    Parity::Environment.new("development",
+                            ["restore", "staging", "--parallelize"]).run
+
+    expect(Parity::Backup).to have_received(:new).
+      with(
+        from: "staging",
+        to: "development",
+        parallelize: true,
+        additional_args: "",
+      )
+    expect(backup).to have_received(:restore)
+  end
+
   it "passes through arguments with correct quoting" do
     Parity::Environment.new(
       "production",
@@ -54,6 +71,7 @@ RSpec.describe Parity::Environment do
       with(
         from: "production",
         to: "staging",
+        parallelize: false,
         additional_args: "--confirm parity-integration-staging",
       )
     expect(backup).to have_received(:restore)
@@ -71,6 +89,7 @@ RSpec.describe Parity::Environment do
       with(
         from: "production",
         to: "staging",
+        parallelize: false,
         additional_args: "--confirm parity-staging",
       )
     expect(backup).to have_received(:restore)
@@ -88,6 +107,7 @@ RSpec.describe Parity::Environment do
       with(
         from: "production",
         to: "staging",
+        parallelize: false,
         additional_args: "--confirm parity-staging",
       )
     expect(backup).to have_received(:restore)
@@ -104,6 +124,7 @@ RSpec.describe Parity::Environment do
       with(
         from: "production",
         to: "staging",
+        parallelize: false,
         additional_args: "--confirm parity-staging",
       )
     expect(backup).to have_received(:restore)
@@ -116,7 +137,12 @@ RSpec.describe Parity::Environment do
     Parity::Environment.new("development", ["restore", "production"]).run
 
     expect(Parity::Backup).to have_received(:new).
-      with(from: "production", to: "development", additional_args: "")
+      with(
+        from: "production",
+        to: "development",
+        parallelize: false,
+        additional_args: "",
+      )
     expect(backup).to have_received(:restore)
   end
 
@@ -127,7 +153,12 @@ RSpec.describe Parity::Environment do
     Parity::Environment.new("development", ["restore", "staging"]).run
 
     expect(Parity::Backup).to have_received(:new).
-      with(from: "staging", to: "development", additional_args: "")
+      with(
+        from: "staging",
+        to: "development",
+        parallelize: false,
+        additional_args: "",
+      )
     expect(backup).to have_received(:restore)
   end
 
@@ -152,7 +183,12 @@ RSpec.describe Parity::Environment do
     Parity::Environment.new("production", ["restore", "staging", "--force"]).run
 
     expect(Parity::Backup).to have_received(:new).
-      with(from: "staging", to: "production", additional_args: "")
+      with(
+        from: "staging",
+        to: "production",
+        parallelize: false,
+        additional_args: "",
+      )
     expect(backup).to have_received(:restore)
   end
 


### PR DESCRIPTION
Per [this issue](https://github.com/thoughtbot/parity/issues/175), right now Parity's default behavior is to attempt to parallelize the `pg_restore` task across multiple cores.  This was causing some parts of the restore op to happen out-of-order, in which case the affected jobs would fail and the restore op as a whole would end unsuccessfully, leaving the DB in a semi-restored state.

This PR removes the default to parallelization, and replaces it with a command line flag which lets the user opt in to parallelization.  The default is now to run `pg_restore` in a single-threaded fashion.