### PR TITLE
Don't delete local temp backup after restore

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -42,7 +42,6 @@ module Parity
       download_remote_backup
       wipe_development_database
       restore_from_local_temp_backup
-      delete_local_temp_backup
       delete_rails_production_environment_settings
     end
 
@@ -79,10 +78,6 @@ module Parity
           "--dbname #{development_db} --jobs=#{processor_cores} "\
           "#{additional_args}",
       )
-    end
-
-    def delete_local_temp_backup
-      Kernel.system("rm tmp/latest.backup")
     end
 
     def delete_rails_production_environment_settings

--- a/spec/parity/backup_spec.rb
+++ b/spec/parity/backup_spec.rb
@@ -25,9 +25,6 @@ describe Parity::Backup do
       expect(Kernel).
         to have_received(:system).
         with(restore_from_local_temp_backup_command)
-      expect(Kernel).
-        to have_received(:system).
-        with(delete_local_temp_backup_command)
     end
 
     it "restores backups to development with Rubies that do not support Etc.nprocessors" do
@@ -53,9 +50,6 @@ describe Parity::Backup do
       expect(Kernel).
         to have_received(:system).
         with(restore_from_local_temp_backup_command(cores: 1))
-      expect(Kernel).
-        to have_received(:system).
-        with(delete_local_temp_backup_command)
     end
 
     it "restores backups in parallel when the right flag is set" do
@@ -81,9 +75,6 @@ describe Parity::Backup do
       expect(Kernel).
         to have_received(:system).
         with(restore_from_local_temp_backup_command(cores: 12))
-      expect(Kernel).
-        to have_received(:system).
-        with(delete_local_temp_backup_command)
     end
 
     it "does not restore backups in parallel when the right flag is set" +
@@ -110,9 +101,6 @@ describe Parity::Backup do
       expect(Kernel).
         to have_received(:system).
         with(restore_from_local_temp_backup_command(cores: 1))
-      expect(Kernel).
-        to have_received(:system).
-        with(delete_local_temp_backup_command)
     end
 
     it "drops the 'ar_internal_metadata' table if it exists" do
@@ -138,9 +126,6 @@ describe Parity::Backup do
       expect(Kernel).
         to have_received(:system).
         with(restore_from_local_temp_backup_command)
-      expect(Kernel).
-        to have_received(:system).
-        with(delete_local_temp_backup_command)
       expect(Kernel).to have_received(:system).with(set_db_metadata_sql)
     end
   end
@@ -224,10 +209,6 @@ describe Parity::Backup do
 
   def number_of_processes
     2
-  end
-
-  def delete_local_temp_backup_command
-    "rm tmp/latest.backup"
   end
 
   def heroku_development_to_staging_passthrough(db_name: default_db_name)


### PR DESCRIPTION
My current database takes about 10 minutes to fetch from Heroku.
If the `pg_restore` fails for any reason, I don't want to re-fetch the dump.

`curl -o` will already overwrite `tmp/latest.backup`
when it begins and `tmp` is ignored in Git by default in Rails apps.

It might be nice if Parity had a command to "restore from local backup"
but in the meantime, this worked well for me:

```
#!/bin/bash
set -euo pipefail

db="MYDB_development"

dropdb --if-exists "$db"
createdb "$db"
time pg_restore tmp/latest.backup --verbose --no-acl --no-owner --dbname "$db"
psql "$db" -c "UPDATE ar_internal_metadata SET value = 'development' WHERE key = 'environment'"
```