### PR TITLE
Don't use --clean flag with pg_restore

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -75,7 +75,7 @@ module Parity
 
     def restore_from_local_temp_backup
       Kernel.system(
-        "pg_restore tmp/latest.backup --verbose --clean --no-acl --no-owner "\
+        "pg_restore tmp/latest.backup --verbose --no-acl --no-owner "\
           "--dbname #{development_db} --jobs=#{processor_cores} "\
           "#{additional_args}",
       )

--- a/spec/parity/backup_spec.rb
+++ b/spec/parity/backup_spec.rb
@@ -218,7 +218,7 @@ describe Parity::Backup do
   end
 
   def restore_from_local_temp_backup_command(cores: number_of_processes)
-    "pg_restore tmp/latest.backup --verbose --clean --no-acl --no-owner "\
+    "pg_restore tmp/latest.backup --verbose --no-acl --no-owner "\
       "--dbname #{default_db_name} --jobs=#{cores} "
   end
 


### PR DESCRIPTION
I noticed some output when restoring my database:

```
pg_restore: dropping TABLE geographic_areas
pg_restore: from TOC entry 266; 1259 16503 TABLE geographic_areas uf1mu7mdqgl0dj
pg_restore: error: could not execute query: ERROR:  table "geographic_areas" does not exist
Command was: DROP TABLE "public"."geographic_areas";
```

It looks like the source of the output was the `--clean` flag:

```
--clean
  Clean (drop) database objects before recreating them. (Unless
  --if-exists is used, this might generate some harmless error messages,
  if any objects were not present in the destination database.)
```

https://www.postgresql.org/docs/current/app-pgrestore.html

As the docs say, these errors are harmless, but noisy.

We don't need the `--clean` flag because the commands Parity runs were:

```
dropdb --if-exists "$db"
createdb "$db"
pg_restore tmp/latest.backup --verbose --clean --no-acl --no-owner --dbname "$db"
```

We've already dropped the whole database, so `--clean` is redundant.