### PR TITLE
Add support for 3-tier database configurations on development

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -5,6 +5,7 @@ module Parity
     BLANK_ARGUMENTS = "".freeze
     DATABASE_YML_RELATIVE_PATH = "config/database.yml".freeze
     DEVELOPMENT_ENVIRONMENT_KEY_NAME = "development".freeze
+    PRIMARY_DATABASE_KEY_NAME = "primary".freeze
     DATABASE_KEY_NAME = "database".freeze
 
     def initialize(args)
@@ -108,9 +109,15 @@ module Parity
     end
 
     def development_db
-      YAML.load(database_yaml_file).
-        fetch(DEVELOPMENT_ENVIRONMENT_KEY_NAME).
-        fetch(DATABASE_KEY_NAME)
+      db_configuration = YAML.load(database_yaml_file).
+        fetch(DEVELOPMENT_ENVIRONMENT_KEY_NAME)
+
+      if db_configuration.key?(PRIMARY_DATABASE_KEY_NAME)
+        db_configuration[PRIMARY_DATABASE_KEY_NAME].
+          fetch(DATABASE_KEY_NAME)
+      else
+        db_configuration.fetch(DATABASE_KEY_NAME)
+      end
     end
 
     def database_yaml_file

--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -109,7 +109,7 @@ module Parity
     end
 
     def development_db
-      db_configuration = YAML.load(database_yaml_file).
+      db_configuration = YAML.safe_load(database_yaml_file).
         fetch(DEVELOPMENT_ENVIRONMENT_KEY_NAME)
 
       if db_configuration.key?(PRIMARY_DATABASE_KEY_NAME)


### PR DESCRIPTION
Hi! I noticed `parity` doesn't get along with multi-database configurations, so I was thinking it could be nice to support this. This patch shows a rough idea of the needed changes, but I wanted to make sure I'm heading in the right direction. Any comments would be greatly appreciated.