### PR TITLE
Feature: #deploy to main or master refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Push your local development database backup up to staging:
 
     staging restore development
 
-Deploy master to production (note that prior versions of Parity would run
+Deploy main to production (note that prior versions of Parity would run
 database migrations, that's now better handled using [Heroku release phase]):
 
     production deploy

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -41,11 +41,24 @@ module Parity
 
     def deploy
       if production?
-        Kernel.system("git push production master")
+        Kernel.system("git push production #{branch_ref}")
       else
         Kernel.system(
-          "git push #{environment} HEAD:master --force",
+          "git push #{environment} HEAD:#{branch_ref} --force",
         )
+      end
+    end
+
+    def branch_ref
+      main_ref_exists = system("git show-ref --verify --quiet refs/heads/main")
+      master_ref_exists = system(
+        "git show-ref --verify --quiet refs/heads/master",
+      )
+
+      if main_ref_exists && !master_ref_exists
+        "main"
+      else
+        "master"
       end
     end
 


### PR DESCRIPTION
Resolves #184 

Heroku has enabled pushing to main by default in a backwards compatible manner (does not affect master branches): https://devcenter.heroku.com/changelog-items/1829

The change checks for the presence of `main` and the absence of `master` -- setting the branch ref appropriately.

Avoids manual / global git configs and doesn't break projects where `master` is still the default branch.