### PR TITLE
Update pr_app character limit

### DIFF
--- a/bin/pr_app
+++ b/bin/pr_app
@@ -9,7 +9,7 @@ if ARGV.empty?
 else
   review_app_number = ARGV.first
   staging_git_remote = Open3.capture3("git remote get-url staging")[0].strip
-  review_app_prefix = staging_git_remote.split("/").last.gsub(/\.git\Z/, "")[0, 22]
+  review_app_prefix = staging_git_remote.split("/").last.gsub(/\.git\Z/, "")[0, 20]
 
   exit Parity::Environment.new(
     "#{review_app_prefix}-pr-#{review_app_number}",


### PR DESCRIPTION
Heroku has a 20 character limit on review app unique identifiers (see below), but code to generate the `pr_app` prefix from the staging remote grabs 22 characters. 

<img width="374" alt="Screen Shot 2021-06-09 at 7 51 55 PM" src="https://user-images.githubusercontent.com/362585/121457205-26334300-c95c-11eb-8a1f-f89332fb634f.png">
