### PR TITLE
Drop non-Rubygem installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,11 @@ Shell commands for development, staging, and production parity for Heroku apps.
 Install
 -------
 
-On macOS, this installs everything you need:
+    gem install parity
 
-    brew tap thoughtbot/formulae
-    brew install parity
+Or bundle it in your project:
 
-On Debian:
-
-    wget -qO - https://apt.thoughtbot.com/thoughtbot.gpg.key | sudo apt-key add -
-    echo "deb http://apt.thoughtbot.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/thoughtbot.list
-    sudo apt-get update
-    sudo apt-get install parity
-
-On other systems you can:
-
-1. Download the package for your system from the [releases page][releases]
-1. Extract the tarball and place it so that `/bin` is in your `PATH`
+    gem "parity"
 
 [releases]: https://github.com/thoughtbot/parity/releases
 
@@ -32,10 +21,6 @@ Parity requires these command-line programs:
     git
     heroku
     pg_restore
-
-On macOS, these programs are installed
-as Homebrew package dependencies of
-the `parity` Homebrew package.
 
 Usage
 -----

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,17 +4,5 @@ Releasing
 1. Update the version in `lib/parity/version.rb`
 1. Create a new tag based on the version number
 1. Create a GitHub [release] for the latest tag
-1. Update the [homebrew formula] to point to the latest GitHub release. Include
-   the path and the SHA.
 
-Development Releases
-====================
-
-Update the [development release] on the repository page, uploading a tarred,
-gzipped collection of files. The Homebrew formula does not require a SHA for a
-development build, and will always point to the file if the name remains
-consistent.
-
-[homebrew formula]: https://github.com/thoughtbot/homebrew-formulae/blob/master/Formula/parity.rb
 [release]: https://github.com/thoughtbot/parity/releases
-[development release]: https://github.com/thoughtbot/parity/releases/tag/development


### PR DESCRIPTION
Since Travelling Ruby is no longer supported, it's no longer feasible
for us to package a self-contained release of Parity that runs
independently of local Rubies. This change acknowledges our trailing
support of Homebrew- and apt-installed Parity and encourages
installation of the Rubygem version instead.

We will remove for formula from thoughtbot's Homebrew formulae in a
subsequent change.
