### PR TITLE
Drop `redis-cli` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,6 @@ Tail a log:
     staging tail
     pr_app 1234 tail
 
-Use [redis-cli][2] with your `REDIS_URL` add-on:
-
-    production redis-cli
-    staging redis-cli
-    pr_app 1234 redis-cli
-
 The scripts also pass through, so you can do anything with them that you can do
 with `heroku ______ --remote staging` or `heroku ______ --remote production`:
 

--- a/lib/parity/environment.rb
+++ b/lib/parity/environment.rb
@@ -126,16 +126,6 @@ module Parity
       )
     end
 
-    def redis_cli
-      Kernel.system("redis-cli", "-u", raw_redis_url)
-    end
-
-    def raw_redis_url
-      @redis_to_go_url ||= Open3.
-        capture3(command_for_remote("config:get REDIS_URL"))[0].
-        strip
-    end
-
     def heroku_app_name
       HerokuAppName.new(environment).to_s
     end

--- a/spec/parity/environment_spec.rb
+++ b/spec/parity/environment_spec.rb
@@ -224,22 +224,6 @@ RSpec.describe Parity::Environment do
     expect(Kernel).to have_received(:exec).with(*open)
   end
 
-  it "opens a Redis session connected to the environment's Redis service" do
-    allow(Open3).to receive(:capture3).and_return(open3_redis_url_fetch_result)
-
-    Parity::Environment.new("production", ["redis_cli"]).run
-
-    expect(Kernel).to have_received(:system).with(
-      "redis-cli",
-      "-u",
-      open3_redis_url_fetch_result[0].strip,
-    )
-    expect(Open3).
-      to have_received(:capture3).
-      with(fetch_redis_url("REDIS_URL")).
-      once
-  end
-
   it "returns true if deploy was successful without migrations" do
     result = Parity::Environment.new("production", ["deploy"]).run
 
@@ -325,18 +309,6 @@ RSpec.describe Parity::Environment do
 
   def open
     ["heroku", "open", "--remote", "production"]
-  end
-
-  def fetch_redis_url(env_variable)
-    "heroku config:get #{env_variable} --remote production"
-  end
-
-  def open3_redis_url_fetch_result
-    [
-      "redis://redistogo:abcd1234efgh5678@landshark.redistogo.com:90210/\n",
-      "",
-      ""
-    ]
   end
 
   def psql_count


### PR DESCRIPTION
Heroku now offers their own `redis:cli` subcommand, making this
unnecessary.

This change will require a major release as we're removing the feature
entirely.
