### PR TITLE
Add aliases: true when loading database.yml in newer Rubies

### DIFF
--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -108,7 +108,7 @@ module Parity
     end
 
     def development_db
-      YAML.load(database_yaml_file).
+      YAML.load(database_yaml_file, aliases: true).
         fetch(DEVELOPMENT_ENVIRONMENT_KEY_NAME).
         fetch(DATABASE_KEY_NAME)
     end

--- a/lib/parity/backup.rb
+++ b/lib/parity/backup.rb
@@ -108,7 +108,7 @@ module Parity
     end
 
     def development_db
-      YAML.load(database_yaml_file, aliases: true).
+      YAML.safe_load(database_yaml_file, aliases: true).
         fetch(DEVELOPMENT_ENVIRONMENT_KEY_NAME).
         fetch(DATABASE_KEY_NAME)
     end


### PR DESCRIPTION
Updated the backup code and added the `aliases: true` option to `YAML.load`. This allows Psych to properly load a `database.yml` file with aliases in newer Rubies.

Fixes #196 